### PR TITLE
Add CI (Release build, format gate) and an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,92 @@
+# EditorConfig — https://editorconfig.org
+#
+# This file is a protected path (see ROADMAP.md section 5). The CI format job runs
+# `dotnet format --verify-no-changes` against it, so every setting here decides whether
+# every future pull request is green. Change one and you are changing the gate.
+#
+# The settings below describe the code as it is rather than as somebody would like it to
+# be: 4-space indent, spaces, LF, final newline, no trailing whitespace, file-scoped
+# namespaces. The tree was audited before this file was written and already satisfies
+# all of it, so the gate starts green and any future red is a real regression rather
+# than a backlog nobody chose.
+
+root = true
+
+# ── Every file ───────────────────────────────────────────────────────────────
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# ── Structured data and workflows ────────────────────────────────────────────
+# YAML cannot use tabs at all, and the estate's workflows are 2-space throughout.
+[*.{yml,yaml}]
+indent_size = 2
+
+# Properties/launchSettings.json is 2-space; so is every JSON emitted by the SDK.
+[*.json]
+indent_size = 2
+
+# Markdown: trailing whitespace is a hard line break in Markdown, so trimming it
+# silently changes rendered output.
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{js,css,html}]
+indent_size = 4
+
+# ── C# ───────────────────────────────────────────────────────────────────────
+[*.cs]
+indent_size = 4
+tab_width = 4
+
+# File-scoped namespaces. Models/SprintModels.cs and Services/SupercompensationService.cs
+# already use them; this records the choice rather than leaving the next file to guess.
+csharp_style_namespace_declarations = file_scoped:suggestion
+
+# Allman braces — the C# default and what the existing code does. Stated explicitly
+# because a formatter default is not a decision anybody made until it is written down.
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+# `using` placement is deliberately left at its default severity. Services/
+# SupercompensationService.cs puts its `using` *inside* the namespace, which is a
+# legitimate style and not something this pull request is changing; raising IDE0065 to
+# error here would fail the build on a file nobody has decided to touch.
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# ── Razor ────────────────────────────────────────────────────────────────────
+# `dotnet format` does not process .razor files — it operates on Roslyn compilation
+# units and Razor markup is not one. These settings are for editors only, and the CI
+# gate does not enforce them. Said plainly so nobody later reads a green build as
+# evidence that the Razor files were checked.
+[*.razor]
+indent_size = 4
+
+# ── Project files ────────────────────────────────────────────────────────────
+[*.{csproj,props,targets}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,9 +6,14 @@
 #
 # The settings below describe the code as it is rather than as somebody would like it to
 # be: 4-space indent, spaces, LF, final newline, no trailing whitespace, file-scoped
-# namespaces. The tree was audited before this file was written and already satisfies
-# all of it, so the gate starts green and any future red is a real regression rather
-# than a backlog nobody chose.
+# namespaces, single-line guard clauses preserved. The tree satisfies all of it, so the
+# gate starts green and any future red is a real regression rather than a backlog nobody
+# chose.
+#
+# One setting in the first draft did not describe the code and the gate caught it on its
+# first run — see `csharp_preserve_single_line_statements` below. Worth knowing before
+# adding a setting here: an .editorconfig entry is an assertion about every existing
+# file, and the only thing that checks it is this repository's own CI.
 
 root = true
 
@@ -69,7 +74,19 @@ csharp_space_before_colon_in_inheritance_clause = true
 csharp_space_after_colon_in_inheritance_clause = true
 csharp_space_around_binary_operators = before_and_after
 
-csharp_preserve_single_line_statements = false
+# Both are the Roslyn defaults, and both are kept because the code relies on them.
+# `preserve_single_line_statements` was briefly set to `false` in the first version of
+# this file and CI rejected it — Services/SupercompensationService.cs `GetPhase` is three
+# parallel single-line guard clauses that read as a table:
+#
+#     if (normalizedDay <= config.FatiguePhaseEnd) return "Fatigue";
+#     if (normalizedDay <= config.RecoveryPhaseEnd) return "Recovery";
+#     return "Supercompensation";
+#
+# `false` would split the first two across six lines and lose the parallelism. The
+# setting was a style nobody had chosen, asserted about code that does the opposite;
+# the audit behind this file checked whitespace and namespaces and did not check it.
+csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
 
 # `using` placement is deliberately left at its default severity. Services/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The first workflow this repository has had. Before it, a pushed commit that did not
+# compile was indistinguishable from one that did — the only thing that ever built this
+# project was a developer running `dotnet run`.
+#
+# Two jobs, deliberately separate: a build failure and a formatting failure are
+# different problems with different fixes, and a single job would report whichever it
+# hit first.
+#
+# There is no `dotnet test` step yet, and its absence is a decision rather than an
+# oversight. `dotnet test` over a solution containing only a Blazor WebAssembly project
+# fails with "no test source files were specified", so a test step added here could not
+# pass without being weakened with `|| true` — which is a gate that does not gate.
+# Issue #6 adds the test project and the step together. See ROADMAP.md section 3.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+# Least privilege: neither job writes anything back to the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # SupercompensationApp.csproj targets net8.0 and pins
+  # Microsoft.AspNetCore.Components.WebAssembly at 8.0.12. Keep this in step with the
+  # csproj: a newer SDK will happily build net8.0, but pinning is what makes a green
+  # build here mean the same thing next month.
+  DOTNET_VERSION: "8.0.x"
+  DOTNET_NOLOGO: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    # A job with no timeout reports nothing when it hangs — for six hours, which is
+    # GitHub's default and not a number anybody chose. This build takes about a minute.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore SupercompensationApp.sln
+
+      # Release rather than Debug: the published WebAssembly build (issue #15) is a
+      # Release build, and Release is where trimming and the linker can surface problems
+      # a Debug build never sees.
+      - name: Build
+        run: dotnet build SupercompensationApp.sln --no-restore --configuration Release
+
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      # `dotnet format` reads project metadata and needs the assets file; without this it
+      # fails on a missing project.assets.json rather than on a formatting problem.
+      - name: Restore
+        run: dotnet restore SupercompensationApp.sln
+
+      # --severity error keeps this to formatting and to analyzer violations that are
+      # already errors. It deliberately does not promote suggestions: the codebase is
+      # consistently formatted today and nothing enforced it, so this job exists to stop
+      # drift, not to relitigate style choices made before it existed.
+      #
+      # Note what is NOT covered: `dotnet format` operates on Roslyn compilation units,
+      # so the six .razor files and wwwroot/js/chart-interop.js are not checked by
+      # anything here. A green result is a claim about the three .cs files.
+      - name: Verify formatting
+        run: dotnet format SupercompensationApp.sln --verify-no-changes --severity error
+
+      # --verify-no-changes reports which files would change and roughly where, which is
+      # enough to find a stray space and not enough to fix a reindented block. On failure,
+      # apply the formatter for real and print the diff, so the log carries the exact
+      # edit the gate is asking for instead of costing a round trip to reproduce.
+      - name: Show the formatting the gate wants
+        if: failure()
+        run: |
+          dotnet format SupercompensationApp.sln --severity error
+          echo "::group::Diff dotnet format would apply"
+          git --no-pager diff --color=always
+          echo "::endgroup::"


### PR DESCRIPTION
Closes #1

## What changed

- `.github/workflows/ci.yml` — two jobs on push to `master`, on PRs to `master`, and
  `workflow_dispatch`:
  - **Build** — `dotnet restore` + `dotnet build --configuration Release`
  - **Format check** — `dotnet format --verify-no-changes --severity error`
- `.editorconfig` at the repository root.

## Why

The repository had no `.github/` directory. Nothing compiled a pushed commit, so a change
that did not build was indistinguishable from one that did, and every acceptance criterion
in the rest of the roadmap is a statement about a green build.

Two jobs rather than one because a build failure and a formatting failure are different
problems with different fixes; a single job reports whichever it reaches first.

## Why `.editorconfig` is in the same PR

`dotnet format --verify-no-changes` without a committed `.editorconfig` measures the
tool's built-in defaults rather than this repository's conventions, and would fail on
already-committed code for reasons nobody chose. The gate and the file it reads are one
deliverable.

The tree was audited before the file was written:

| Checked | Result |
|---|---|
| Trailing whitespace, all 13 source files | 0 |
| Tab characters in `.cs` | 0 |
| Missing final newline | 0 |
| CRLF line endings | 0 (`.gitattributes` line 4 is `* text=auto`) |
| Namespace style in both `.cs` files with one | file-scoped |
| Indent width, `.cs` / `.js` / `.css` / `.html` | 4 |
| Indent width, `launchSettings.json` | 2 |

## The gate caught the gate's own author, first run

That audit was not sufficient, and the honest place to say so is here rather than in a
comment nobody scrolls to. The first push was **green on Build and red on Format check**:

```
Services/SupercompensationService.cs(43,53): error WHITESPACE: Fix whitespace formatting.
Services/SupercompensationService.cs(44,54): error WHITESPACE: Fix whitespace formatting.
```

The cause was `csharp_preserve_single_line_statements = false` in the first draft of
`.editorconfig` — not the Roslyn default, and the opposite of what the code does.
`GetPhase` is three parallel single-line guard clauses that read as a table:

```csharp
if (normalizedDay <= config.FatiguePhaseEnd) return "Fatigue";
if (normalizedDay <= config.RecoveryPhaseEnd) return "Recovery";
return "Supercompensation";
```

`false` splits the first two across six lines and loses the parallelism.

**The fix is the setting, not the source.** An `.editorconfig` entry is an assertion about
every existing file; that one asserted a style the codebase does not use and nobody had
chosen. Reverting it to the default corrects a false claim rather than weakening a gate —
whitespace, indentation, brace placement and spacing are all still enforced, and the
audit's blind spot is now written into the file's header so the next setting added here
gets checked against the code rather than against taste.

Second push: **both jobs green.**

The `if: failure()` step earned its place on its first run — `--verify-no-changes` reports
which files would change and roughly where, which is enough to find a stray space and not
enough to fix a reindented block. The log carried the exact diff, so the fix took one
round trip instead of two.

Three settings are deliberately *not* tightened, each with the reason in a comment:
`csharp_style_namespace_declarations` stays at `suggestion`; `using`-directive placement is
left at its default severity, because `Services/SupercompensationService.cs` puts its
`using` inside the namespace and promoting IDE0065 would fail the build on a file this PR
is not touching; and `trim_trailing_whitespace` is switched **off** for Markdown, where two
trailing spaces are a hard line break and trimming them changes rendered output.

## What the green tick does and does not cover

`dotnet format` operates on Roslyn compilation units. The six `.razor` files and
`wwwroot/js/chart-interop.js` are **not** checked by anything in this PR. That is stated in
a comment in both files so a green build is not later read as evidence they were checked.
Issue #3 brings `chart-interop.js` under CodeQL, which is the closest this repository gets
to a JavaScript gate.

## No `dotnet test` step

`dotnet test` over a solution containing only a Blazor WebAssembly project fails with *"no
test source files were specified"*. The alternatives were a step that cannot pass, or one
weakened with `|| true` — which is a gate that does not gate. #6 adds the test project and
the step together. `ROADMAP.md` §3 records the sequencing.

## Verification

- Build: green (SDK 8.0.424, `net8.0`).
- Format check: red on the first push for the reason above, green on the second.
- **This PR is gated by the workflow it adds** — a `pull_request`-triggered workflow
  introduced by a PR from a branch in this repository runs on that PR. Both jobs' first
  real execution, including a genuine failure and its fix, is on this page. That is the
  only way to know a new check is looking at anything.

One thing noted and not acted on: the runner warns that `actions/checkout@v4` and
`actions/setup-dotnet@v4` target Node 20, which is deprecated and being forced onto Node 24.
Both still run. Bumping them is #4's job, which is what dependency automation is for.

## Protected path

`.github/workflows/**` and `.editorconfig` are both protected paths (`ROADMAP.md` §5). Per
the execution policy a CI failure here after three attempts is **not** force-merged — the
PR stays open and labelled `blocked`. It did not come to that: two attempts, and the second
was green.