### PR TITLE
Add gitleaks secret scanning over full history

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,68 @@
+name: Secret scan
+
+# ─────────────────────────────────────────────────────────────────────────────
+# P5 of konradcinkusz/architecture-standards makes this mandatory and states the
+# assumption it exists to falsify: "a repository without one is assumed to contain
+# credentials until proven otherwise".
+#
+# Worth having even though this application is client-only and holds no server-side
+# secrets today, for two reasons. It scans *history*, so what it establishes is a claim
+# about every commit that has ever existed rather than about the working tree. And the
+# moment this repository gains a deploy workflow (#15) or a key for a data source, the
+# scanner needs to have been here already — installing it after the leak is theatre.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch: {}
+
+# A secret scanner has no reason to hold any write permission, and this is the workflow
+# where that matters most: it is the one that reads every credential-shaped string in
+# the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history. A secret removed in the tip commit is still a leaked secret,
+          # and scanning only the working tree would call that clean.
+          fetch-depth: 0
+
+      # The container rather than gitleaks-action, deliberately. The action additionally
+      # enumerates a pull request's commits through the API and fails the job with
+      # "Resource not accessible by integration" without `pull-requests: read` — a
+      # permission a secret scanner has no reason to hold. This runs the same scanner
+      # over the same history and needs nothing but the checkout.
+      #
+      # Pinned rather than :latest. The trade is real and goes the other way from most
+      # pins: a secret scanner's value is partly in *new* rules, so a stale image is a
+      # scanner that cannot see this year's token formats. It is pinned anyway because
+      # a moving tag can also change the CLI out from under the job — `detect` is
+      # already the deprecated spelling of `git` in the 8.x line — and a scanner that
+      # fails to start detects nothing at all.
+      #
+      # Dependabot (#4) covers NuGet and Actions and CANNOT see this: an image reference
+      # inside a `run:` step is a string to it. Bumping this is a manual review item.
+      # Verified against 8.28.0 locally: full history (6 commits, 93.6 KB) scans clean,
+      # and a probe file carrying a plausible AWS key, GitHub PAT and Slack bot token is
+      # caught (3 findings, exit 1).
+      - name: Scan history
+        run: |
+          docker run --rm -v "$PWD:/repo" -w /repo zricethezav/gitleaks:v8.28.0 git /repo \
+            --config=/repo/.gitleaks.toml \
+            --redact \
+            --no-banner \
+            --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,39 @@
+# gitleaks configuration
+#
+# This file is a protected path (see ROADMAP.md section 5): the secret-scan workflow
+# reads it, so a change here changes what every future push is scanned for. Widening an
+# allowlist is the one edit in this repository that can make a gate quietly stop
+# gating.
+#
+# P5 of konradcinkusz/architecture-standards makes the scanner mandatory and states the
+# assumption it exists to falsify: "a repository without one is assumed to contain
+# credentials until proven otherwise".
+
+title = "SupercompensationApp secret scan"
+
+[extend]
+# The full upstream ruleset, unmodified. This repository has no reason to disable a
+# rule: it is a client-only WebAssembly page with no server, no configuration files and
+# no credentials of its own, so every default rule is either irrelevant (costing
+# nothing) or a genuine finding.
+useDefault = true
+
+# ── Allowlist ────────────────────────────────────────────────────────────────
+# Deliberately almost empty. The whole history was scanned with gitleaks 8.28.0 before
+# this file was committed and reported zero leaks, so nothing here is silencing a
+# finding — every entry below is a path the scanner has no business reading in the
+# first place.
+#
+# Add an entry only for a confirmed false positive, and say in a comment which finding
+# it suppresses and why it is not real. An allowlist entry with no such comment should
+# be treated as a defect in review.
+[allowlist]
+description = "Paths with no source of record"
+paths = [
+    # Build output. Blazor WebAssembly emits the compiled application and its runtime
+    # here; anything found in it came from a file that is itself scanned.
+    '''^bin/''',
+    '''^obj/''',
+    '''(^|/)bin/''',
+    '''(^|/)obj/''',
+]


### PR DESCRIPTION
Closes #2

## What changed

- `.github/workflows/secret-scan.yml` — gitleaks over full history, on every branch and
  every PR.
- `.gitleaks.toml` — the upstream ruleset unmodified, with an allowlist covering `bin/`
  and `obj/` only.

## Why

P5 of `konradcinkusz/architecture-standards` makes the scanner mandatory and states the
assumption it exists to falsify: *"a repository without one is assumed to contain
credentials until proven otherwise."* This repository had no scanner, so that assumption
stood.

It is worth having even though the app is client-only and holds no server-side secrets
today. It scans **history**, so the claim it establishes is about every commit that has
ever existed rather than about the working tree — and the moment this repository gains a
deploy workflow (#15) or a key for a data source, the scanner needs to have been here
already. Installing it after the leak is theatre.

## Verified locally, not left for CI to discover

Docker is unavailable in the authoring environment but the gitleaks release binary is not,
so both halves were run against 8.28.0 before pushing:

| | Result |
|---|---|
| Full history (`gitleaks git`), 6 commits, 93.6 KB | **no leaks found**, exit 0 |
| Probe file with a plausible AWS key, GitHub PAT and Slack bot token | **3 findings**, exit 1 |
| Probe removed, re-scan | clean, exit 0 |

**The first probe attempt did not fire, and that is the part worth reporting.** It used
`AKIAIOSFODNN7EXAMPLE` — which is AWS's own documentation key and sits in gitleaks'
default allowlist. A scanner test built on a well-known example proves nothing, and had I
stopped at "the scan is green" I would have shipped a job I had no evidence was looking at
anything. The probe was rewritten with credential-shaped strings that are not published
anywhere, and then it fired.

## Two decisions worth flagging

**Pinned to `v8.28.0`, not `:latest`** — and the trade runs the opposite way from most
pins. A secret scanner's value is partly in *new* rules, so a stale image cannot see this
year's token formats; `:latest` is the defensible default and is what the estate's other
repositories use. It is pinned anyway because a moving tag can change the CLI out from
under the job — `detect` is already the deprecated spelling of `git` within the 8.x line —
and a scanner that fails to start detects nothing at all. Both spellings were confirmed
working in 8.28.0; the workflow uses the current one.

The cost is stated in the workflow comment rather than hidden: **Dependabot (#4) cannot
see this.** An image reference inside a `run:` step is an opaque string to it, so bumping
the pin is a manual review item.

**The container rather than `gitleaks-action`**, following `authservice`. The action
additionally enumerates a PR's commits through the API and fails with *"Resource not
accessible by integration"* without `pull-requests: read` — a permission a secret scanner
has no reason to hold. The container needs nothing but the checkout, and this workflow runs
at `contents: read`.

## On the allowlist

Almost empty on purpose: `bin/` and `obj/`, which are build output whose contents come
from files that are themselves scanned. **Nothing here is silencing a finding** — the scan
was clean before the file existed. The config says in as many words that an allowlist entry
without a comment naming the finding it suppresses should be treated as a defect in review,
because widening an allowlist is the one edit in this repository that can make a gate
quietly stop gating.

## Scope note

REPO-BASELINE §2 asks for a pre-commit hook **and** a CI job. This PR is the CI job only.

A hook cannot be installed by a commit — every contributor has to run `git config
core.hooksPath` or equivalent on their own machine — so it is documentation rather than
automation, and it belongs in `CONTRIBUTING.md` (#17) where a new contributor will actually
read it. Recorded here rather than left as a silent half-implementation. The CI job is the
half that catches contributors without hooks, which is the half that cannot be skipped.

## Protected paths

`.github/workflows/**` and `.gitleaks.toml` are both protected paths (`ROADMAP.md` §5).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_