### PR TITLE
Add CodeQL analysis for C# and JavaScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,83 @@
+name: CodeQL
+
+# ─────────────────────────────────────────────────────────────────────────────
+# REPO-BASELINE section 1 lists SAST against the failure it prevents: "static analysis
+# exists only when a human remembers to run it".
+#
+# Two languages, and the JavaScript leg is the one that would have been easy to leave
+# out. wwwroot/js/chart-interop.js is 243 lines of DOM and Blob work — including a
+# downloadCsv helper that builds an object URL and a link element out of strings
+# produced in C# — and it is checked by nothing else in this repository: `dotnet format`
+# operates on Roslyn compilation units, so neither it nor the build has ever read that
+# file.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly. The scheduled run is not redundant with the PR runs: it is what catches a
+    # query-pack update finding something in code that has not changed. A SAST tool that
+    # only ever runs on diffs can only ever find what this week's diff introduced.
+    - cron: "27 5 * * 1"
+  workflow_dispatch: {}
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      # Writing the SARIF results back to the Security tab is the whole point; this is
+      # the one permission the job genuinely needs.
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        if: matrix.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          # Kept in step with ci.yml and with SupercompensationApp.csproj's net8.0.
+          dotnet-version: "8.0.x"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # `manual` rather than `autobuild`, and rather than the buildless `none` mode that
+      # C# now supports. CodeQL's C# extractor observes a real compilation; a run that
+      # compiles nothing analyses nothing and reports success either way, which is the
+      # failure mode this job exists to avoid rather than to reproduce. Spelling the
+      # build out also means the job log shows it, so a green tick is checkable.
+      - name: Build
+        if: matrix.language == 'csharp'
+        run: |
+          dotnet restore SupercompensationApp.sln
+          dotnet build SupercompensationApp.sln --no-restore --configuration Release
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #3

## What changed

`.github/workflows/codeql.yml` — a two-leg matrix (`csharp`, `javascript-typescript`) on
push to `master`, PRs to `master`, a weekly schedule, and `workflow_dispatch`.

## Why

REPO-BASELINE §1 lists SAST against the failure it prevents: *"static analysis exists only
when a human remembers to run it."*

## The JavaScript leg is the one that matters here

It would have been easy to configure this for C# alone and call it done.
`wwwroot/js/chart-interop.js` is **243 lines** of DOM and Blob work — including a
`downloadCsv` helper that constructs an object URL and a link element out of strings built
in C# — and it is currently read by **nothing** in this repository:

| Gate | Covers `chart-interop.js`? |
|---|---|
| `dotnet build` (#1) | No — not a compilation input |
| `dotnet format` (#1) | No — operates on Roslyn compilation units |
| gitleaks (#2) | Only for credential-shaped strings |

So a C#-only CodeQL configuration would have left the repository's only unanalysed source
file unanalysed, while displaying a green SAST tick. This is the same shape as the note in
#1's PR about what a green format check does and does not cover.

## `build-mode: manual`, not `autobuild` and not `none`

C# now supports buildless analysis, and `autobuild` would probably have worked. Neither is
used, for the reason the issue names: CodeQL's C# extractor analyses what a compiler
actually compiled, and **a run that compiles nothing analyses nothing and reports success
either way** — which is precisely the failure this job exists to prevent rather than to
reproduce.

Spelling the build out has a second benefit: it appears in the job log, so the acceptance
criterion ("confirm the job log shows the build") is checkable rather than trusted. The
`dotnet-version` is pinned to `8.0.x`, in step with `ci.yml` and the csproj's `net8.0`.

`javascript-typescript` uses `build-mode: none`, which is correct — there is nothing to
build.

## The weekly schedule is not redundant

The PR runs and the scheduled run catch different things. A SAST tool that only ever runs
on diffs can only find what this week's diff introduced; the scheduled run is what surfaces
a **query-pack update** finding something in code that has not changed since it was written.

## Permissions

`security-events: write` (writing SARIF to the Security tab is the point), plus
`contents: read` and `actions: read`. Nothing wider.

## If the first run fails on entitlement

CodeQL requires a public repository or GitHub Advanced Security. If it is unavailable on
this repository's plan, the correct outcome is **not** a permanently red workflow: per the
issue, record the reason in a comment and close as `not_planned`. A gate that is red on
something nobody can clear teaches the next person to stop reading the output — the same
reasoning `ROADMAP.md` applies to the force-merge rule.

Any alert the first successful run raises will be fixed here or recorded in a follow-up
issue with its rule id. Alerts will not be dismissed silently.

## Protected path

`.github/workflows/**` (`ROADMAP.md` §5) — not force-mergeable after three failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_