### PR TITLE
Add CODEOWNERS, a pull request template and issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# Code owners
+#
+# REPO-BASELINE section 1 lists this file against the failure it prevents:
+# "security-relevant paths merged without the right reviewer".
+#
+# The explicit entries below are not decoration. They are the PROTECTED PATHS from
+# ROADMAP.md section 5 — the files whose breakage compromises every later pull request
+# rather than one feature. A broken CSS rule is contained; a broken format gate or
+# validator turns every subsequent pull request into three-retries-and-force-merge,
+# which is CI ceasing to exist.
+#
+# Listing them here means the set exists in two places on purpose: in ROADMAP.md with
+# the reasoning, and here where GitHub enforces it. If you add a protected path to one,
+# add it to the other.
+
+# ── Everything ───────────────────────────────────────────────────────────────
+*                               @konradcinkusz
+
+# ── Protected: the automation that gates every other change ──────────────────
+/.github/                       @konradcinkusz
+/.github/workflows/             @konradcinkusz
+/.gitleaks.toml                 @konradcinkusz
+
+# ── Protected: the build ─────────────────────────────────────────────────────
+/SupercompensationApp.csproj    @konradcinkusz
+/SupercompensationApp.sln       @konradcinkusz
+/Directory.Build.props          @konradcinkusz
+/Directory.Packages.props       @konradcinkusz
+
+# ── Protected: the format gate reads this, so it decides whether every pull
+#    request is green ──────────────────────────────────────────────────────────
+/.editorconfig                  @konradcinkusz

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Something the app does that it should not
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+
+
+## What you expected instead
+
+
+
+## Sprint parameters
+
+<!--
+This app's defects vary with its inputs — a curve or a chart that is fine at
+SprintDuration = 10 can be wrong at 7, because several bugs are ratios rather than
+constants. Please give the values from the Konfiguracja tab, or say "defaults".
+-->
+
+| | |
+|---|---|
+| Czas trwania sprintu | |
+| Liczba sprintów | |
+| Przyrost baseline | |
+| Początkowy baseline | |
+| Głębokość zmęczenia | |
+| Szczyt superkompensacji | |
+| Liczba członków zespołu | |
+
+## Browser and locale
+
+<!--
+Locale is not a formality here. Blazor WebAssembly takes its culture from the browser,
+and several known defects depend on it — a decimal comma changes how numbers are parsed
+from the inputs and written into the exported CSV. If you are not sure, run this in the
+browser console and paste the result:
+
+    navigator.language, Intl.NumberFormat().resolvedOptions().locale
+-->
+
+- Browser and version:
+- Locale:
+
+## Anything else
+
+<!-- A screenshot, the exported CSV, or a console error. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature request
+about: Something the app should do and does not
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## The problem
+
+<!-- What you are trying to do that the app makes hard or impossible. -->
+
+
+
+## What you propose
+
+
+
+## What it buys a user of the model
+
+<!--
+This is a modelling tool, so the useful question is what a reader could conclude with
+this that they cannot conclude today. "It would look nicer" is a fine answer if that is
+the honest one — say so rather than inventing an analytical justification.
+-->
+
+
+
+## Scope check
+
+<!--
+ROADMAP.md lists things this repository has decided not to do: a backend or accounts,
+changing the mathematical model, localisation beyond the Polish UI, and moving off .NET 8
+or Chart.js. If your request touches one of those, say why it is worth reopening the
+decision — it is not an automatic no.
+-->
+
+- [ ] I have read the non-goals in [`ROADMAP.md`](../blob/master/ROADMAP.md)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## What changed
+
+
+
+## Why
+
+
+
+## How it was verified
+
+<!--
+What you actually ran or looked at, not what should pass. Several defects in this
+repository were invisible in a diff and visible only on the rendered page — the chart
+title painted in its own background colour is the standing example. If a change affects
+what the chart looks like, say you looked at it.
+-->
+
+
+
+## Checklist
+
+- [ ] Closes an issue (`Closes #N`), or says why it does not
+- [ ] **Touches a protected path** — `.github/**`, the `.csproj`/`.sln`,
+      `Directory.*.props`, `.editorconfig`, `.gitleaks.toml`. If so, this cannot be
+      merged over a red CI run; see `ROADMAP.md` §5–6.
+- [ ] CI is green, or the failure is diagnosed in a comment


### PR DESCRIPTION
Closes #5

## What changed

- `.github/CODEOWNERS`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, `config.yml`

## Why

REPO-BASELINE §1 lists `CODEOWNERS` against *"security-relevant paths merged without the
right reviewer"* and templates against *"reviews and reports without repro/impact"*,
adding that *"templates are the cheapest process you can install."*

## CODEOWNERS is the protected-path list, enforced

It is not a single catch-all line. Its explicit entries **are** the protected paths from
`ROADMAP.md` §5 — the files whose breakage compromises every later PR rather than one
feature. The set now lives in two places deliberately: in the roadmap with its reasoning,
and here where GitHub acts on it.

Cross-checked programmatically rather than by eye — every path §5 names resolves inside
the file:

```
ROADMAP lists: .github/workflows/**, SupercompensationApp.csproj, SupercompensationApp.sln,
               Directory.Build.props, Directory.Packages.props, .editorconfig, .gitleaks.toml
MISSING from CODEOWNERS: none
```

(The checker also flagged `.github/CODEOWNERS`, which it picked up from §5's closing
sentence rather than from the list. It is covered regardless, by the `/.github/` entry.)

`Directory.Build.props` and `Directory.Packages.props` are listed before they exist — #6
adds them, and an ownership rule that arrives after the file it protects is a rule that was
absent exactly when the file was introduced.

## The bug template asks for two unusual things, and both earn their place

**Sprint parameters.** Several of this application's known defects are *ratios* rather than
constants — the phase-band misplacement in #9 scales as `pointsPerSprint / SprintDuration`,
so it is invisible in the one configuration where those happen to be equal and wrong
everywhere else. A report without the parameters may not be reproducible at all. The
template is a table of the six fields from the Konfiguracja tab plus team size, with
"defaults" as an acceptable answer.

**Locale.** Blazor WebAssembly takes its culture from the browser, and this app ships
`<html lang="pl">`. A decimal comma changes how the numeric inputs parse *and* what the
exported CSV contains (#10) — so "the CSV is broken" and "the CSV is fine" can both be true
reports of the same build. Rather than expecting a reporter to know their locale, the
template gives the console line that prints it:

```js
navigator.language, Intl.NumberFormat().resolvedOptions().locale
```

## The other two

**PR template** — what changed, why, how verified, and a checklist whose middle item is the
protected-path flag, since that is what decides whether a red CI run can be force-merged.
The "how it was verified" prompt asks for what was actually run or looked at, and names the
chart-title defect as the reason: several bugs here are invisible in a diff and visible only
on the rendered page.

**Feature template** — asks what a change buys a *user of the model*, and says outright that
"it would look nicer" is a fine answer if it is the honest one, rather than inviting an
invented analytical justification. It links the roadmap's non-goals and frames them as
reopenable rather than as an automatic no.

Kept short on purpose. The issue's own reasoning applies: a template nobody fills in is
worse than none.

## Verification

- Both issue templates' YAML front-matter parses; `config.yml` parses and disables blank
  issues.
- CODEOWNERS coverage checked against ROADMAP §5 by script (above).
- `grep -riE 'credential|token|password|secret|api[_-]?key|env variable'` across all four
  templates: **no matches.** This application has no secrets, and a template section
  inviting one is how that stops being true.

This closes Phase 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_