### PR TITLE
Pin the supercompensation curve with unit tests

### DIFF
--- a/tests/SupercompensationApp.Tests/SupercompensationCurveTests.cs
+++ b/tests/SupercompensationApp.Tests/SupercompensationCurveTests.cs
@@ -1,0 +1,381 @@
+namespace SupercompensationApp.Tests;
+
+using SupercompensationApp.Models;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// Pins the supercompensation curve.
+///
+/// The README states the model as a table of three formulas; nothing checked that the
+/// code still computes that table. These are the properties a careless edit breaks, and
+/// none of them can be seen by looking at a rendered chart: the branches are three
+/// separate arithmetic expressions and the joins between them are implicit, so a change
+/// to any one can break a join without breaking a build.
+///
+/// Note what this is NOT. CalculateDeviation is continuous as written today — these
+/// tests are not a bug report, they are what stops that becoming false silently.
+///
+/// Every property is asserted at two configurations: the defaults, and a second set
+/// chosen so that no assertion can accidentally depend on D = 25, P = 18, a 10-day
+/// sprint or a 7-person team.
+/// </summary>
+public class SupercompensationCurveTests
+{
+    private const double FatigueEnd = 0.5;
+    private const double RecoveryEnd = 0.8;
+
+    /// <summary>The two configurations every property below is checked against.</summary>
+    private static (string Name, SprintConfiguration Config)[] Configurations() =>
+    [
+        ("defaults", new SprintConfiguration()),
+        ("non-default", new SprintConfiguration
+        {
+            SprintDuration = 7,
+            NumberOfSprints = 5,
+            InitialBaseline = 120.0,
+            BaselineIncrement = 8.5,
+            FatigueDepth = 40.0,
+            SupercompensationPeak = 12.0,
+        }),
+    ];
+
+    private static List<TeamMember> SmallTeam() =>
+    [
+        new() { Name = "A", Role = "Developer", Weight = 1.0 },
+        new() { Name = "B", Role = "QA", Weight = 0.5 },
+    ];
+
+    // ── Phase classification ─────────────────────────────────────────────────
+    //
+    // The comparisons in GetPhase are `<=`, so 0.5 is Fatigue and 0.8 is Recovery.
+    // Which side of a boundary falls into which phase is a decision; it belongs in a
+    // test rather than being rediscovered from the source every time somebody asks.
+
+    [Fact]
+    public void PhaseBoundariesFallOnTheLowerPhase()
+    {
+        var service = new SupercompensationService();
+
+        foreach (var (name, config) in Configurations())
+        {
+            AssertPhase(service, config, name, 0.0, "Fatigue");
+            AssertPhase(service, config, name, 0.25, "Fatigue");
+            AssertPhase(service, config, name, FatigueEnd, "Fatigue");
+
+            AssertPhase(service, config, name, 0.5000001, "Recovery");
+            AssertPhase(service, config, name, 0.65, "Recovery");
+            AssertPhase(service, config, name, RecoveryEnd, "Recovery");
+
+            AssertPhase(service, config, name, 0.8000001, "Supercompensation");
+            AssertPhase(service, config, name, 1.0, "Supercompensation");
+        }
+    }
+
+    private static void AssertPhase(
+        SupercompensationService service,
+        SprintConfiguration config,
+        string configName,
+        double t,
+        string expected)
+    {
+        var actual = service.GetPhase(t, config);
+        Assert.True(
+            actual == expected,
+            $"[{configName}] The phase at t={t} should be {expected} but was {actual}. " +
+            $"The boundaries are inclusive on the lower phase: 0.5 is the last Fatigue " +
+            $"point and 0.8 is the last Recovery point.");
+    }
+
+    // ── Endpoints ────────────────────────────────────────────────────────────
+    //
+    // The first three are EXACT and the fourth is not, and the difference is not
+    // pedantry. f(0), f(0.5) and f(0.8) fall out of multiplication and subtraction on
+    // values that are their own quotients, so no rounding enters. f(1) goes through
+    // Math.Sin, whose result is a property of the runtime's libm rather than of this
+    // model — so it gets a bound. Asserting a remembered figure there would be
+    // committing an observation where an invariant was meant.
+
+    [Fact]
+    public void ASprintStartsExactlyOnTheBaseline()
+    {
+        var service = new SupercompensationService();
+
+        foreach (var (name, config) in Configurations())
+        {
+            var value = service.CalculateDeviation(0.0, config);
+            Assert.True(
+                value == 0.0,
+                $"[{name}] A sprint must start on the baseline, so the deviation at t=0 " +
+                $"is exactly 0. Got {value}.");
+        }
+    }
+
+    [Fact]
+    public void TheTroughIsExactlyTheConfiguredFatigueDepth()
+    {
+        var service = new SupercompensationService();
+
+        foreach (var (name, config) in Configurations())
+        {
+            var value = service.CalculateDeviation(FatigueEnd, config);
+            Assert.True(
+                value == -config.FatigueDepth,
+                $"[{name}] The fatigue phase must bottom out at exactly the configured " +
+                $"depth, -{config.FatigueDepth}. Got {value}. If this drifts, the number " +
+                $"the user typed is not the number the chart shows.");
+        }
+    }
+
+    [Fact]
+    public void RecoveryReturnsExactlyToTheBaseline()
+    {
+        var service = new SupercompensationService();
+
+        foreach (var (name, config) in Configurations())
+        {
+            var value = service.CalculateDeviation(RecoveryEnd, config);
+            Assert.True(
+                value == 0.0,
+                $"[{name}] Recovery must return exactly to the baseline at t=0.8 — that is " +
+                $"what makes the phase boundary meaningful. Got {value}.");
+        }
+    }
+
+    [Fact]
+    public void TheSprintEndsAtTheConfiguredSupercompensationPeak()
+    {
+        var service = new SupercompensationService();
+
+        // The model's own arithmetic is exact here; the sine is not. One ulp at the
+        // magnitude of the peak is the honest ceiling, and it holds on any libm.
+        foreach (var (name, config) in Configurations())
+        {
+            var value = service.CalculateDeviation(1.0, config);
+            var slack = Math.Abs(value - config.SupercompensationPeak);
+
+            // Note what is NOT used here: C#'s double.Epsilon is the smallest denormal
+            // (about 5e-324), not machine epsilon. A tolerance written in terms of it
+            // reads like a relative ulp bound and is effectively zero.
+            var ceiling = 1e-12 * Math.Max(1.0, Math.Abs(config.SupercompensationPeak));
+
+            Assert.True(
+                slack <= ceiling,
+                $"[{name}] A sprint must end at the configured supercompensation peak, " +
+                $"{config.SupercompensationPeak}. Got {value}, off by {slack}, which is " +
+                $"more than rounding in Math.Sin can account for.");
+        }
+    }
+
+    // ── Continuity at the joins ──────────────────────────────────────────────
+
+    [Fact]
+    public void TheCurveIsContinuousAtBothJoins()
+    {
+        var service = new SupercompensationService();
+        const double Step = 1e-6;
+
+        foreach (var (name, config) in Configurations())
+        {
+            foreach (var join in new[] { FatigueEnd, RecoveryEnd })
+            {
+                var below = service.CalculateDeviation(join - Step, config);
+                var above = service.CalculateDeviation(join + Step, config);
+                var jump = Math.Abs(above - below);
+
+                // The bound is DERIVED rather than measured, so it holds on any runner.
+                // A remembered residual would be a property of the machine that measured
+                // it. Either side moves at most (slope x Step) away from the join, so
+                // what is needed is the steepest slope on the curve, in normalised-day
+                // units:
+                //
+                //   fatigue           d/dx [-D (x/0.5)^2]        peaks at 4 D
+                //   recovery          d/dx [-D (1-u)^2],  u=(x-0.5)/0.3   peaks at 2D/0.3
+                //   supercompensation d/dx [P sin(u pi/2)], u=(x-0.8)/0.2 peaks at (pi/2)P/0.2
+                //
+                // The last two are about 6.7 D and 7.9 P — steeper than the first, which
+                // is the mistake in an earlier draft of this test. 8 x max(D, P) covers
+                // all three with room to spare.
+                var slopeBound = 8.0 * Math.Max(config.FatigueDepth, config.SupercompensationPeak);
+                var ceiling = 3.0 * slopeBound * Step;
+
+                Assert.True(
+                    jump <= ceiling,
+                    $"[{name}] The curve must not step at the join t={join}: the value " +
+                    $"just below is {below} and just above is {above}, a jump of {jump}. " +
+                    $"Two adjacent branches disagreeing at a boundary is a discontinuity " +
+                    $"the chart will draw as a vertical line.");
+            }
+        }
+    }
+
+    // ── Monotonicity ─────────────────────────────────────────────────────────
+    //
+    // This is the assertion that catches a sign error in one branch. A flipped sign
+    // still produces a smooth, plausible curve; it just runs the wrong way.
+
+    [Fact]
+    public void TheCurveFallsThroughFatigueAndRisesAllTheWayBack()
+    {
+        var service = new SupercompensationService();
+        const int Samples = 200;
+
+        foreach (var (name, config) in Configurations())
+        {
+            AssertStrictlyMonotonic(
+                service, config, name, from: 0.0, to: FatigueEnd, Samples, rising: false);
+
+            AssertStrictlyMonotonic(
+                service, config, name, from: FatigueEnd, to: 1.0, Samples, rising: true);
+        }
+    }
+
+    private static void AssertStrictlyMonotonic(
+        SupercompensationService service,
+        SprintConfiguration config,
+        string configName,
+        double from,
+        double to,
+        int samples,
+        bool rising)
+    {
+        var previous = service.CalculateDeviation(from, config);
+
+        for (var i = 1; i <= samples; i++)
+        {
+            var t = from + ((to - from) * i / samples);
+            var current = service.CalculateDeviation(t, config);
+            var ordered = rising ? current > previous : current < previous;
+
+            Assert.True(
+                ordered,
+                $"[{configName}] The curve must be strictly " +
+                $"{(rising ? "increasing" : "decreasing")} across " +
+                $"[{from}, {to}], but at t={t} it went from {previous} to {current}. " +
+                $"A sign error in one branch produces a curve that is still smooth and " +
+                $"still plausible, and runs the wrong way.");
+
+            previous = current;
+        }
+    }
+
+    // ── Aggregates ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EverySprintGetsASummaryAtItsOwnBaseline()
+    {
+        var service = new SupercompensationService();
+        var team = SmallTeam();
+        var teamWeight = service.CalculateTeamWeight(team);
+
+        foreach (var (name, config) in Configurations())
+        {
+            var data = service.GenerateChartData(config, team);
+
+            Assert.True(
+                data.Summaries.Count == config.NumberOfSprints,
+                $"[{name}] There must be one summary per sprint: expected " +
+                $"{config.NumberOfSprints}, got {data.Summaries.Count}.");
+
+            for (var s = 0; s < config.NumberOfSprints; s++)
+            {
+                var summary = data.Summaries[s];
+                var expected = Math.Round(
+                    (config.InitialBaseline + (s * config.BaselineIncrement)) * teamWeight, 2);
+
+                Assert.True(
+                    summary.Baseline == expected,
+                    $"[{name}] Sprint {s + 1}'s baseline must be the progressive baseline " +
+                    $"scaled by the team weight: expected {expected}, got {summary.Baseline}.");
+
+                Assert.True(
+                    summary.PeakPerformance > summary.Baseline,
+                    $"[{name}] Sprint {s + 1} must peak above its baseline (the peak is " +
+                    $"what supercompensation means): baseline {summary.Baseline}, peak " +
+                    $"{summary.PeakPerformance}.");
+
+                Assert.True(
+                    summary.MinPerformance < summary.Baseline,
+                    $"[{name}] Sprint {s + 1} must dip below its baseline during fatigue: " +
+                    $"baseline {summary.Baseline}, min {summary.MinPerformance}.");
+
+                Assert.True(
+                    summary.DeliveryValue > 0.0,
+                    $"[{name}] Sprint {s + 1}'s delivery value is the area above the " +
+                    $"baseline and must be positive; got {summary.DeliveryValue}.");
+            }
+        }
+    }
+
+    [Fact]
+    public void DeliveryValueScalesWithSprintLengthBecauseItIsAnIntegral()
+    {
+        // DeliveryValue is an accumulation over sprint days, not a rate. It sits on the
+        // summary card beside peak and min, which ARE rates — so the fact that only this
+        // one moves when the sprint gets longer is the property worth pinning.
+        var service = new SupercompensationService();
+        var team = SmallTeam();
+
+        var shortSprint = new SprintConfiguration { SprintDuration = 10, NumberOfSprints = 1 };
+        var longSprint = new SprintConfiguration { SprintDuration = 20, NumberOfSprints = 1 };
+
+        var shortValue = service.GenerateChartData(shortSprint, team).Summaries[0].DeliveryValue;
+        var longValue = service.GenerateChartData(longSprint, team).Summaries[0].DeliveryValue;
+
+        // Exact in the arithmetic — doubling the duration doubles dt and nothing else —
+        // so the only slack needed is the rounding to two decimal places that
+        // GenerateChartData applies to both figures.
+        var difference = Math.Abs(longValue - (2.0 * shortValue));
+
+        Assert.True(
+            difference <= 0.02,
+            $"Doubling the sprint length must double the delivery value, because it is " +
+            $"an integral over sprint days: 10 days gave {shortValue}, 20 days gave " +
+            $"{longValue}, and twice the first is {2.0 * shortValue}.");
+    }
+
+    // ── Table ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheTableIsOneRowPerDayWithConsistentOneBasedIndices()
+    {
+        var service = new SupercompensationService();
+        var team = SmallTeam();
+
+        foreach (var (name, config) in Configurations())
+        {
+            var rows = service.GenerateTableData(config, team);
+            var expectedRows = config.NumberOfSprints * config.SprintDuration;
+
+            Assert.True(
+                rows.Count == expectedRows,
+                $"[{name}] The table must have one row per day: expected {expectedRows} " +
+                $"({config.NumberOfSprints} sprints x {config.SprintDuration} days), got " +
+                $"{rows.Count}.");
+
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var row = rows[i];
+
+                Assert.True(
+                    row.Day == i + 1,
+                    $"[{name}] Days must run 1..{expectedRows} with no gaps; row {i} " +
+                    $"reports day {row.Day}.");
+
+                var expectedSprint = (i / config.SprintDuration) + 1;
+                var expectedDayInSprint = (i % config.SprintDuration) + 1;
+
+                Assert.True(
+                    row.SprintNumber == expectedSprint,
+                    $"[{name}] Day {row.Day} belongs to sprint {expectedSprint}, but the " +
+                    $"row says {row.SprintNumber}. Every Quiz route and summary reference " +
+                    $"in the UI navigates by these numbers.");
+
+                Assert.True(
+                    row.DayInSprint == expectedDayInSprint,
+                    $"[{name}] Day {row.Day} is day {expectedDayInSprint} of its sprint, " +
+                    $"but the row says {row.DayInSprint}.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #7

## What changed

`tests/SupercompensationApp.Tests/SupercompensationCurveTests.cs` — eight tests over
seven properties. No production code changes.

## Why

The README states the model as a table of three formulas. Nothing checked that the code
still computes that table.

To be clear about what this is **not**: `CalculateDeviation` is continuous as written
today, and these tests are not a bug report. The joins between its three branches are
implicit in three separate arithmetic expressions, so a change to any one of them can
break a join without breaking a build — and the result renders as a perfectly smooth,
perfectly wrong chart.

Every property is asserted at the defaults **and** at a second configuration
(`SprintDuration = 7`, `NumberOfSprints = 5`, `D = 40`, `P = 12`, two-person team), so no
assertion can accidentally depend on `D = 25`, `P = 18`, a 10-day sprint or a 7-person team.

## Exact where it is provable, bounded where it is not

This split is the substance of the PR rather than pedantry:

| Property | Assertion | Why |
|---|---|---|
| `f(0) = 0` | **exact** | `−D·t²` with `t` exactly 0 |
| `f(0.5) = −D` | **exact** | `t = 0.5/0.5` is exactly 1 |
| `f(0.8) = 0` | **exact** | `t = (0.8−0.5)/(0.8−0.5)` is exactly 1, whatever `0.8−0.5` rounds to |
| `f(1) = +P` | **bounded** | goes through `Math.Sin` — a property of the runtime's libm, not of this model |
| continuity at both joins | **bounded** | a derived slope bound, not a measured residual |

`f(0)` and `f(0.8)` both evaluate to **`−0.0`**, which compares equal to `0.0`, so the
exact assertions hold.

No test asserts a remembered floating-point residual. A committed figure there is a
property of the machine that measured it and fails on a different runner.

## Two errors in my own first draft, caught before pushing

**The slope bound was wrong.** Continuity was bounded using `4 × max(D, P)` as the
steepest slope on the curve. That is *branch one's* maximum. Working the other two out:

```
fatigue            d/dx[ −D (x/0.5)² ]                        peaks at 4·D
recovery           d/dx[ −D (1−u)² ],  u = (x−0.5)/0.3        peaks at 2D/0.3  ≈ 6.7·D
supercompensation  d/dx[ P sin(uπ/2) ], u = (x−0.8)/0.2       peaks at (π/2)P/0.2 ≈ 7.9·P
```

The two later branches are *steeper*. The bound is now `8 × max(D, P)`, with the
derivation written into the comment so the next person can check it rather than trust it.

**The sine tolerance was written in terms of `double.Epsilon`.** In C# that is the
smallest **denormal** (≈5e-324), not machine epsilon. Written into a tolerance it reads
like a relative ulp bound and is effectively zero. Replaced with an honest absolute
bound, and the trap is noted in a comment.

## Verified numerically before pushing, not left for CI

Every bound was checked against an independent reimplementation of the three formulas:

```
defaults     join 0.5: jump=6.667e-05  ceiling=6.000e-04   9.0x margin
defaults     join 0.8: jump=1.414e-04  ceiling=6.000e-04   4.2x margin
non-default  join 0.5: jump=1.067e-04  ceiling=9.600e-04   9.0x margin
non-default  join 0.8: jump=9.425e-05  ceiling=9.600e-04  10.2x margin

strictly decreasing on [0, 0.5]:  0 violations  (both configs)
strictly increasing on [0.5, 1]:  0 violations  (both configs)

delivery(10 days) = 35.05    delivery(20 days) = 70.10    |20d − 2×10d| = 0.0000
```

## The two properties worth arguing for

**Monotonicity, 200 samples per branch.** This is what catches a sign error. A flipped
sign still produces a smooth, plausible curve — it just runs the wrong way, and nothing
else in this repository would notice.

**`DeliveryValue` scales with sprint length.** It is an *integral over sprint days*
sitting on the summary card next to peak and min, which are instantaneous. Doubling the
sprint doubles it and leaves the other two alone. The assertion is the ratio, not the
figure — a figure would break the moment anyone touches `FatigueDepth`. Slack is 0.02,
which is exactly the rounding to two decimals that `GenerateChartData` applies to both
operands.

## Failure messages

Each says what the property is, not just which numbers differed — *"Recovery must return
exactly to the baseline at t=0.8 — that is what makes the phase boundary meaningful"*
rather than `Assert.Equal() Failure`. Each is prefixed with which of the two
configurations failed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_