### PR TITLE
Give the chart a linear x axis: phase bands and sprint boundaries were misplaced

### DIFF
--- a/wwwroot/js/chart-interop.js
+++ b/wwwroot/js/chart-interop.js
@@ -60,6 +60,17 @@ function readPalette() {
     };
 }
 
+/**
+ * Pairs the day array with a value array into Chart.js {x, y} points.
+ *
+ * This is what keeps the x axis a value axis. Passing a bare value array alongside
+ * `labels` is what produced the category scale that misplaced every band and boundary
+ * line — see the comment on scales.x below.
+ */
+function toPoints(days, values) {
+    return values.map((value, i) => ({ x: days[i], y: value }));
+}
+
 let chartInstance = null;
 
 window.renderSupercompChart = function (days, performance, baselines, phases, sprintBoundaries, showPhases, showBaseline, sprintDuration) {
@@ -98,7 +109,7 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
 
         datasets.push({
             label: 'Wydajność zespołu',
-            data: performance,
+            data: toPoints(days, performance),
             borderColor: function (context) {
                 const index = context.dataIndex;
                 return pointColors[index] || withAlpha(palette.blue, 0.9);
@@ -119,7 +130,7 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
     } else {
         datasets.push({
             label: 'Wydajność zespołu',
-            data: performance,
+            data: toPoints(days, performance),
             borderColor: palette.blue,
             backgroundColor: withAlpha(palette.blue, 0.1),
             borderWidth: 3,
@@ -134,7 +145,7 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
     if (showBaseline) {
         datasets.push({
             label: 'Baseline',
-            data: baselines,
+            data: toPoints(days, baselines),
             borderColor: withAlpha(palette.textSecondary, 0.8),
             backgroundColor: 'transparent',
             borderWidth: 2,
@@ -170,7 +181,6 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
     chartInstance = new Chart(ctx, {
         type: 'line',
         data: {
-            labels: days,
             datasets: datasets
         },
         options: {
@@ -197,9 +207,16 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
                     cornerRadius: 8,
                     callbacks: {
                         title: function (items) {
-                            const day = items[0].label;
-                            const sprint = Math.floor(day / sprintDuration) + 1;
-                            const dayInSprint = (day % sprintDuration) + 1;
+                            // `items[0].label` is a STRING on a category axis and a
+                            // fractional day on a linear one; `parsed.x` is the number
+                            // either way. The day-in-sprint is floored because a reader
+                            // is being told which day of the sprint they are looking at,
+                            // and "dzień 6.4" is not one — the old code reported exactly
+                            // that at any fractional x.
+                            const day = items[0].parsed.x;
+                            const total = sprintBoundaries.length + 1;
+                            const sprint = Math.min(Math.floor(day / sprintDuration) + 1, total);
+                            const dayInSprint = Math.floor(day % sprintDuration) + 1;
                             return `Dzień ${day} (Sprint ${sprint}, dzień ${dayInSprint})`;
                         },
                         label: function (item) {
@@ -220,6 +237,21 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
             },
             scales: {
                 x: {
+                    // LINEAR, and this is the whole fix. With `labels: days` and no
+                    // explicit type, Chart.js gives this scale a CATEGORY axis, where
+                    // positions are addressed by point INDEX rather than by value. Two
+                    // features then passed day values where an index was expected: the
+                    // phase bands via getPixelForValue(day), and the sprint boundary
+                    // annotations via xMin/xMax. At 50 points per sprint over a 10-day
+                    // sprint that is a factor of five, so every band and every boundary
+                    // line was squeezed into the opening fifth of the chart while the
+                    // curve itself was drawn correctly across the full width.
+                    //
+                    // Day is a continuous quantity — GenerateChartData already emits it
+                    // fractional, rounded to 2dp — so a linear scale is what this always
+                    // should have been.
+                    type: 'linear',
+                    bounds: 'data',
                     title: {
                         display: true,
                         text: 'Dzień',
@@ -257,8 +289,20 @@ window.renderSupercompChart = function (days, performance, baselines, phases, sp
 
                 const ctx = chart.ctx;
                 const xAxis = chart.scales.x;
-                const yAxis = chart.scales.y;
                 const chartArea = chart.chartArea;
+
+                // The bands are positioned by DAY VALUE, so they are only meaningful on
+                // a value scale. If this axis is ever made categorical again,
+                // getPixelForValue would silently reinterpret every day as an ordinal
+                // and the bands would land in the wrong place while still looking
+                // deliberate. Drawing nothing is the better failure: a missing band is
+                // noticed, a misplaced one is not.
+                if (xAxis.type !== 'linear') {
+                    console.warn(
+                        'supercompChart: the x scale is "' + xAxis.type + '", not linear. ' +
+                        'Phase bands are positioned by day value and have been skipped.');
+                    return;
+                }
 
                 // Draw colored backgrounds for each sprint's phases
                 const totalDays = days.length > 0 ? days[days.length - 1] : 0;


### PR DESCRIPTION
Closes #9

## The defect

The chart was built with `labels: days` and no explicit `scales.x.type`, so Chart.js gave
it a **category** scale — where positions are addressed by point *index*, not by value.
Two features then passed day values where an index was expected:

- the phase backgrounds, via `xAxis.getPixelForValue(sprintStart + duration * 0.5)`
- the sprint boundary annotations, via `xMin: boundary` / `xMax: boundary`

Nothing errored. The chart rendered, the curve was drawn correctly, and the decoration was
wrong — the class of defect that survives review because it looks deliberate.

## Measured, at two ratios

The error is the ratio `pointsPerSprint / SprintDuration`, so **one configuration cannot
distinguish a fix from a coincidence** — the issue asks for two, and here they are. Driven
in headless Chromium against the real `chart-interop.js`, reported as a fraction of plot
width:

| Config | Element | Drawn at | Should be | |
|---|---|---|---|---|
| 10-day × 3, 50 pts | boundary day 10 | **6.7%** | 33.3% | ÷5 |
| | boundary day 20 | **13.3%** | 66.7% | ÷5 |
| | band edge day 8 | **5.3%** | 26.7% | ÷5 |
| 7-day × 5, 50 pts | boundary day 7 | **2.8%** | 20.0% | ÷7.14 |
| | boundary day 28 | **11.2%** | 80.0% | ÷7.14 |
| | band edge day 5.6 | **2.2%** | 16.0% | ÷7.14 |

Factors of exactly **5** and **7.14** — the two ratios. After the change **all eight
positions are exact in both configurations**, and `x.type` reports `linear` instead of
`category`.

Screenshots are attached to the session. In the after shot the green bands sit on days
8–10, 18–20 and 28–30 — the last 20% of each sprint — and line up with the green
supercompensation segments of the curve, which is what they were always meant to indicate.

## The fix

Datasets now carry `{x, y}` points and the scale is declared `linear`. Day is a continuous
quantity — `GenerateChartData` already emits it fractional, rounded to 2dp — so this is
what the axis always should have been, and neither call site needs a conversion: both now
mean what they already assumed they meant.

## Two things fixed while in there

**The tooltip.** It read `items[0].label`, which is a *string* on a category axis and a
fractional day on a linear one, then did `(day % sprintDuration) + 1` — reporting
*"dzień 6.4"* at any fractional x. It now reads `items[0].parsed.x` and floors the
day-in-sprint, and clamps the sprint number so the final point does not report sprint N+1.

**A structural guard, rather than a value assertion.** The issue suggested asserting that
the last day equals `numSprints × sprintDuration`. I did something narrower that catches
the actual failure mode: the phase-band plugin now checks `xAxis.type !== 'linear'` and
**draws nothing**, with a console warning naming the scale it found.

That is deliberately not a correctness check on the data — it is a check on the
*assumption the drawing code makes*. If someone reintroduces a category axis, the bands
disappear rather than reappearing in the wrong place. A missing band gets noticed; a
misplaced one is what shipped.

## Note for #16

This changes chart behaviour that the README describes, which is why #16 (documenting the
model's assumptions) is sequenced after this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_