### PR TITLE
Make the CSV export culture-invariant

### DIFF
--- a/Pages/Chart.razor
+++ b/Pages/Chart.razor
@@ -117,11 +117,11 @@
     {
         if (Index.LastTableData is null) return;
 
-        var csv = "Day,Sprint,DayInSprint,Phase,Baseline,Deviation,Performance\n";
-        foreach (var p in Index.LastTableData)
-        {
-            csv += $"{p.Day},{p.SprintNumber},{p.DayInSprint},{p.Phase},{p.Baseline},{p.Deviation},{p.Performance}\n";
-        }
+        // The formatting lives in Services/CsvExporter so a unit test can reach it. It
+        // used to be string interpolation here, which formats a double with the CURRENT
+        // culture — and under pl-PL, which is what this app's own <html lang="pl">
+        // invites, every decimal comma became an extra field separator.
+        var csv = CsvExporter.ToCsv(Index.LastTableData);
 
         await JS.InvokeVoidAsync("downloadCsv", csv, "supercompensation_data.csv");
     }

--- a/Services/CsvExporter.cs
+++ b/Services/CsvExporter.cs
@@ -1,0 +1,97 @@
+namespace SupercompensationApp.Services;
+
+using System.Globalization;
+using System.Text;
+using SupercompensationApp.Models;
+
+/// <summary>
+/// Renders the day-by-day table as RFC 4180 CSV.
+///
+/// This lives here rather than inline in Pages/Chart.razor for one reason: an event
+/// handler in a .razor file cannot be reached by a unit test, and the defect this class
+/// exists to fix is one that only a test under a second culture can catch.
+///
+/// The defect: the export used string interpolation, which formats a double with
+/// CultureInfo.CurrentCulture. Blazor WebAssembly takes its culture from the browser,
+/// this application ships &lt;html lang="pl"&gt; and its entire UI is Polish, so the
+/// overwhelmingly likely current culture is pl-PL — whose decimal separator is a COMMA.
+/// A row that should read
+///
+///     1,1,1,Fatigue,656.25,0,656.25
+///
+/// was written as
+///
+///     1,1,1,Fatigue,656,25,0,656,25
+///
+/// Three numeric fields became six, the header declared seven columns and the rows
+/// carried ten, and every spreadsheet opened it without complaint and misaligned the
+/// data. A CSV's field separator and its decimal point are not negotiable per user.
+/// </summary>
+public static class CsvExporter
+{
+    /// <summary>
+    /// RFC 4180 specifies CRLF, and it is what Excel expects.
+    /// </summary>
+    private const string LineEnding = "\r\n";
+
+    private static readonly string[] Header =
+    [
+        "Day", "Sprint", "DayInSprint", "Phase", "Baseline", "Deviation", "Performance",
+    ];
+
+    public static string ToCsv(IReadOnlyList<SprintDataPoint> points)
+    {
+        ArgumentNullException.ThrowIfNull(points);
+
+        // StringBuilder rather than `csv +=` in a loop, which is quadratic. The UI's own
+        // maximums allow 20 sprints x 30 days, so this runs over up to 600 rows.
+        var builder = new StringBuilder();
+
+        builder.Append(string.Join(',', Header)).Append(LineEnding);
+
+        foreach (var point in points)
+        {
+            builder
+                .Append(Number(point.Day)).Append(',')
+                .Append(Number(point.SprintNumber)).Append(',')
+                .Append(Number(point.DayInSprint)).Append(',')
+                .Append(Field(point.Phase)).Append(',')
+                .Append(Number(point.Baseline)).Append(',')
+                .Append(Number(point.Deviation)).Append(',')
+                .Append(Number(point.Performance))
+                .Append(LineEnding);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Formats a number for the file rather than for a reader. InvariantCulture is the
+    /// point of this whole class.
+    /// </summary>
+    private static string Number(double value) =>
+        value.ToString(CultureInfo.InvariantCulture);
+
+    private static string Number(int value) =>
+        value.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Quotes a text field if it contains anything that would otherwise break the row.
+    ///
+    /// Phase is a controlled vocabulary today — Fatigue, Recovery, Supercompensation —
+    /// so nothing here needs quoting yet. It is done anyway because a CSV writer that
+    /// cannot quote a field is one string change away from the same class of bug this
+    /// class was written to fix, and the escaping is four lines.
+    /// </summary>
+    private static string Field(string? value)
+    {
+        var text = value ?? string.Empty;
+
+        if (text.IndexOfAny([',', '"', '\r', '\n']) < 0)
+        {
+            return text;
+        }
+
+        return string.Concat("\"", text.Replace("\"", "\"\"", StringComparison.Ordinal), "\"");
+    }
+}

--- a/tests/SupercompensationApp.Tests/CsvExporterTests.cs
+++ b/tests/SupercompensationApp.Tests/CsvExporterTests.cs
@@ -1,0 +1,191 @@
+namespace SupercompensationApp.Tests;
+
+using System.Globalization;
+using SupercompensationApp.Models;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// The export used to be string interpolation inside a .razor event handler, which
+/// formats a double with CultureInfo.CurrentCulture. Blazor WebAssembly takes its
+/// culture from the browser and this application ships &lt;html lang="pl"&gt;, so the
+/// likely current culture is pl-PL — whose decimal separator is a comma.
+///
+/// These tests run the exporter under three cultures. Nothing else in this repository
+/// could have caught the defect: it is invisible in a diff, invisible under en-US, and
+/// the resulting file opens in every spreadsheet without an error.
+/// </summary>
+public class CsvExporterTests
+{
+    /// <summary>
+    /// pl-PL is the app's own audience, de-DE is a second comma-decimal culture so no
+    /// assertion can accidentally depend on Polish specifically, and en-US is the
+    /// point-decimal control.
+    /// </summary>
+    private static readonly string[] Cultures = ["pl-PL", "de-DE", "en-US"];
+
+    private static List<SprintDataPoint> Sample() =>
+    [
+        new()
+        {
+            Day = 1, SprintNumber = 1, DayInSprint = 1, Phase = "Fatigue",
+            Baseline = 656.25, Deviation = -0.5, Performance = 655.75, TeamWeight = 6.35,
+        },
+        new()
+        {
+            Day = 2, SprintNumber = 1, DayInSprint = 2, Phase = "Supercompensation",
+            Baseline = 656.25, Deviation = 114.3, Performance = 770.55, TeamWeight = 6.35,
+        },
+    ];
+
+    /// <summary>
+    /// Runs an action with CurrentCulture forced, and always puts it back. Culture is
+    /// ambient state and xUnit runs test classes in parallel, so leaking it would make
+    /// an unrelated test fail somewhere else.
+    /// </summary>
+    private static T UnderCulture<T>(string culture, Func<T> action)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(culture);
+            return action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void TheCultureSwitchInTheseTestsActuallyDoesSomething()
+    {
+        // Guards the test harness rather than the code under test, and it is not
+        // ceremony. If the runtime were built without ICU — or with
+        // InvariantGlobalization — then new CultureInfo("pl-PL") silently yields
+        // invariant behaviour, every assertion below would pass, and the suite would
+        // report that a culture bug is fixed while never having exercised a second
+        // culture at all. A check that cannot fail is not a check.
+        var polish = UnderCulture("pl-PL", () => 1.5.ToString(CultureInfo.CurrentCulture));
+
+        Assert.True(
+            polish == "1,5",
+            $"Under pl-PL a bare double should format with a decimal COMMA, but this " +
+            $"runtime produced \"{polish}\". Globalization is not active here, so every " +
+            $"other test in this class is passing vacuously — fix the runtime, do not " +
+            $"relax this assertion.");
+    }
+
+    [Fact]
+    public void TheFileIsIdenticalUnderEveryCulture()
+    {
+        var reference = UnderCulture("en-US", () => CsvExporter.ToCsv(Sample()));
+
+        foreach (var culture in Cultures)
+        {
+            var actual = UnderCulture(culture, () => CsvExporter.ToCsv(Sample()));
+
+            Assert.True(
+                actual == reference,
+                $"The exported CSV must not depend on the machine's culture, but under " +
+                $"{culture} it differs from en-US.\n--- {culture} ---\n{actual}\n" +
+                $"--- en-US ---\n{reference}");
+        }
+    }
+
+    [Fact]
+    public void EveryRowHasExactlyAsManyFieldsAsTheHeader()
+    {
+        // This is the assertion that would have caught the original defect. Under pl-PL
+        // the three double fields each became two, so the header declared seven columns
+        // and every row carried ten — and no spreadsheet complains about that.
+        foreach (var culture in Cultures)
+        {
+            var csv = UnderCulture(culture, () => CsvExporter.ToCsv(Sample()));
+            var lines = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+            var headerFields = lines[0].Split(',').Length;
+
+            Assert.True(
+                headerFields == 7,
+                $"[{culture}] The header must declare 7 columns; it declared {headerFields}.");
+
+            for (var i = 1; i < lines.Length; i++)
+            {
+                var fields = lines[i].Split(',').Length;
+                Assert.True(
+                    fields == headerFields,
+                    $"[{culture}] Row {i} has {fields} fields against the header's " +
+                    $"{headerFields}. A decimal comma in a comma-separated file splits " +
+                    $"its own row, and the result opens without an error in every " +
+                    $"spreadsheet.\nRow: {lines[i]}");
+            }
+        }
+    }
+
+    [Fact]
+    public void DecimalsUseAPointEvenUnderACommaDecimalCulture()
+    {
+        var csv = UnderCulture("pl-PL", () => CsvExporter.ToCsv(Sample()));
+
+        Assert.True(
+            csv.Contains("656.25", StringComparison.Ordinal),
+            $"[pl-PL] A decimal must be written with a point in a comma-separated file. " +
+            $"Got:\n{csv}");
+    }
+
+    [Fact]
+    public void RowsAreTerminatedWithCrLfAsRfc4180Requires()
+    {
+        var csv = CsvExporter.ToCsv(Sample());
+
+        Assert.True(
+            csv.EndsWith("\r\n", StringComparison.Ordinal),
+            "RFC 4180 specifies CRLF, and it is what Excel expects.");
+
+        var bareNewlines = csv.Replace("\r\n", string.Empty, StringComparison.Ordinal)
+                              .Count(c => c == '\n');
+        Assert.True(
+            bareNewlines == 0,
+            $"Found {bareNewlines} bare LF line endings; every row must end CRLF.");
+    }
+
+    [Fact]
+    public void AFieldContainingASeparatorIsQuoted()
+    {
+        // Phase is a controlled vocabulary today, so this cannot happen yet. The test
+        // exists because a CSV writer that cannot quote is one string change away from
+        // the same class of defect this class was written to fix.
+        var points = new List<SprintDataPoint>
+        {
+            new()
+            {
+                Day = 1, SprintNumber = 1, DayInSprint = 1,
+                Phase = "Fatigue, deep", Baseline = 1.5, Deviation = 0.0, Performance = 1.5,
+            },
+        };
+
+        var csv = CsvExporter.ToCsv(points);
+        var row = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries)[1];
+
+        Assert.True(
+            row.Contains("\"Fatigue, deep\"", StringComparison.Ordinal),
+            $"A field containing the separator must be quoted, or it splits its own row. " +
+            $"Got: {row}");
+
+        Assert.True(
+            row.Split(',').Length == 8,
+            $"Sanity check on the test itself: the quoted field is expected to make a " +
+            $"naive split report 8 pieces for 7 columns, which is why a naive split is " +
+            $"not how a CSV is read. Got {row.Split(',').Length}.");
+    }
+
+    [Fact]
+    public void AnEmptyTableStillProducesItsHeader()
+    {
+        var csv = CsvExporter.ToCsv([]);
+
+        Assert.True(
+            csv == "Day,Sprint,DayInSprint,Phase,Baseline,Deviation,Performance\r\n",
+            $"An export with no rows must still be a valid CSV with its header. Got:\n{csv}");
+    }
+}


### PR DESCRIPTION
Closes #10

## What changed

- `Services/CsvExporter.cs` — new; the formatting, extracted so a test can reach it.
- `Pages/Chart.razor` — `ExportCsv` now calls it.
- `tests/…/CsvExporterTests.cs` — seven tests across `pl-PL`, `de-DE`, `en-US`.

## The defect

`ExportCsv` built the file with string interpolation, which formats a `double` using
`CultureInfo.CurrentCulture`. Blazor WebAssembly takes its culture from the browser; this
app ships `<html lang="pl">` with an entirely Polish UI, so the likely current culture is
`pl-PL` — decimal separator **comma**.

```
should be:   1,1,1,Fatigue,656.25,-0.5,655.75      7 fields
was:         1,1,1,Fatigue,656,25,-0,5,655,75     10 fields
```

Three numeric fields became six. The header declared seven columns and the rows carried
ten — and the file opens in every spreadsheet **without an error**, which is why nobody
notices until a number is read out of the wrong column.

## Why it moved out of the .razor file

An event handler in a `.razor` file cannot be reached by a unit test, and this defect is
invisible in a diff, invisible under `en-US`, and produces a file that opens cleanly. A
test under a second culture is the only thing that catches it.

## The tests

Seven. `de-DE` is in there so nothing can accidentally depend on Polish specifically;
`en-US` is the point-decimal control. The load-bearing one is
`EveryRowHasExactlyAsManyFieldsAsTheHeader` — the assertion that would have caught the
original.

**One test guards the harness rather than the code**, and it is not ceremony:

```csharp
var polish = UnderCulture("pl-PL", () => 1.5.ToString(CultureInfo.CurrentCulture));
Assert.True(polish == "1,5", ...);
```

Without ICU, or under `InvariantGlobalization`, `new CultureInfo("pl-PL")` silently yields
invariant behaviour. Every other test in the file would then pass and the suite would
report a culture bug fixed **while never having exercised a second culture at all**. A
check that cannot fail is not a check — the same lesson the gitleaks probe in #2 and the
`dotnet test` probe in #6 each cost a round to learn.

Also fixed while in there: RFC 4180 CRLF endings, quoting for any field containing a
separator/quote/newline, and a `StringBuilder` replacing `csv +=` in a loop over up to
600 rows (the UI's own maximums are 20 sprints × 30 days).

The quoting test deliberately covers a case that **cannot arise today** — `Phase` is a
controlled vocabulary of three values. A CSV writer that cannot quote a field is one
string change away from the same class of defect, and the escaping is four lines.

## The other half of the issue, and why I did not change it

The issue also asks for `@bind:culture="CultureInfo.InvariantCulture"` on the numeric
inputs, on the reasoning that `@bind` parses with the current culture while
`<input type="number">` always presents a dot-decimal value per the HTML spec.

🔀 **DECISION: not changed, because Blazor already does this.** `@bind` on a plain element
is driven by `Microsoft.AspNetCore.Components.Web.BindAttributes`, and the entry for
`number` is declared with `isInvariantCulture: true` — the framework special-cases
`type="number"` and `type="date"` precisely because the HTML spec mandates invariant
formatting for them. Adding `@bind:culture` to eight inputs would be a no-op that reads
like a fix.

**Stated honestly: I could not execute this to confirm it**, because there is no .NET SDK
in this environment and asserting it would need bUnit, which this repository does not
have. It rests on the framework's declared binding attribute rather than on a run. If it
turns out to be wrong, the symptom is a team weight of `0.95` refusing to parse under
`pl-PL`, and the fix is the one the issue describes. The confirmed defect — the export —
is fixed and tested here.

I have added a note to #13, which touches those same inputs, so whoever picks it up sees
this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_