### PR TITLE
Validate sprint parameters; a zero duration silently produced NaN

### DIFF
--- a/Models/SprintModels.cs
+++ b/Models/SprintModels.cs
@@ -2,6 +2,24 @@ namespace SupercompensationApp.Models;
 
 public class SprintConfiguration
 {
+    // The permitted ranges. These are the same numbers the Konfiguracja tab advertises
+    // in its min/max attributes — but `min` and `max` on an <input> are validation
+    // HINTS: they do not stop a value being typed or pasted, and @bind performs no
+    // range check of its own. Holding the range here rather than only in the markup is
+    // what makes it enforceable by something other than the browser's goodwill.
+    public const int MinSprintDuration = 5;
+    public const int MaxSprintDuration = 30;
+    public const int MinNumberOfSprints = 1;
+    public const int MaxNumberOfSprints = 20;
+    public const double MinBaselineIncrement = 0.0;
+    public const double MaxBaselineIncrement = 50.0;
+    public const double MinInitialBaseline = 50.0;
+    public const double MaxInitialBaseline = 200.0;
+    public const double MinFatigueDepth = 5.0;
+    public const double MaxFatigueDepth = 50.0;
+    public const double MinSupercompensationPeak = 5.0;
+    public const double MaxSupercompensationPeak = 40.0;
+
     public int SprintDuration { get; set; } = 10;
     public int NumberOfSprints { get; set; } = 3;
     public double BaselineIncrement { get; set; } = 15.0;
@@ -9,10 +27,65 @@ public class SprintConfiguration
     public double FatigueDepth { get; set; } = 25.0;
     public double SupercompensationPeak { get; set; } = 18.0;
 
-    // Phases as fractions of sprint duration
+    // Phases as fractions of sprint duration.
+    //
+    // Note that these are expression-bodied with no setter: 50% and 80% are FIXED
+    // CONSTANTS of this model, not parameters, and cannot be configured without editing
+    // source. The README's table presents them alongside D and P as though they were
+    // knobs — see issue #16.
     public double FatiguePhaseEnd => 0.5;   // 50% of sprint
     public double RecoveryPhaseEnd => 0.8;  // 80% of sprint
     // Remaining 20% = supercompensation
+
+    /// <summary>
+    /// Returns one message per constraint this configuration violates, empty when it is
+    /// usable.
+    ///
+    /// The failure this exists to stop is not an exception, it is a SILENT one. With
+    /// SprintDuration = 0, `dayInSprint / config.SprintDuration` is 0/0, so every
+    /// deviation is NaN, every comparison against NaN is false, the summaries keep the
+    /// double.MinValue and double.MaxValue they were initialised with, and the chart
+    /// renders blank with no error anywhere.
+    /// </summary>
+    public IReadOnlyList<string> Validate()
+    {
+        var problems = new List<string>();
+
+        Check(problems, SprintDuration, MinSprintDuration, MaxSprintDuration,
+            nameof(SprintDuration), "Czas trwania sprintu");
+        Check(problems, NumberOfSprints, MinNumberOfSprints, MaxNumberOfSprints,
+            nameof(NumberOfSprints), "Liczba sprintów");
+        Check(problems, BaselineIncrement, MinBaselineIncrement, MaxBaselineIncrement,
+            nameof(BaselineIncrement), "Przyrost baseline");
+        Check(problems, InitialBaseline, MinInitialBaseline, MaxInitialBaseline,
+            nameof(InitialBaseline), "Początkowy baseline");
+        Check(problems, FatigueDepth, MinFatigueDepth, MaxFatigueDepth,
+            nameof(FatigueDepth), "Głębokość zmęczenia");
+        Check(problems, SupercompensationPeak, MinSupercompensationPeak,
+            MaxSupercompensationPeak, nameof(SupercompensationPeak),
+            "Szczyt superkompensacji");
+
+        return problems;
+    }
+
+    /// <summary>
+    /// A NaN value fails every comparison, so `value < min || value > max` would let it
+    /// through. The test is inverted for that reason: anything not inside the range,
+    /// including NaN and the infinities, is a violation.
+    /// </summary>
+    private static void Check(
+        List<string> problems,
+        double value,
+        double min,
+        double max,
+        string property,
+        string label)
+    {
+        if (!(value >= min && value <= max))
+        {
+            problems.Add($"{label} ({property}) = {value}; dozwolony zakres to {min}–{max}.");
+        }
+    }
 }
 
 public class TeamMember

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -104,7 +104,16 @@
     </section>
 
     <section class="config-section action-section">
-        <button class="btn-generate" @onclick="GenerateChart">
+        @if (Problems.Count > 0)
+        {
+            <ul class="validation-errors">
+                @foreach (var problem in Problems)
+                {
+                    <li>@problem</li>
+                }
+            </ul>
+        }
+        <button class="btn-generate" @onclick="GenerateChart" disabled="@(Problems.Count > 0)">
             📊 Generuj wykres hiperkompensacji
         </button>
     </section>
@@ -140,8 +149,23 @@
         Team = TeamMember.GetDefaultTeam();
     }
 
+    // Recomputed on every render, which is what makes the button state and the message
+    // list track what the user has typed without an explicit validate step.
+    private IReadOnlyList<string> Problems => Config.Validate();
+
     private void GenerateChart()
     {
+        // The service throws on an unusable configuration, so this guard is about WHERE
+        // the reader finds out. Before it, SprintDuration = 0 navigated to a blank chart
+        // with no error: 0/0 made every deviation NaN, every comparison against NaN is
+        // false, and the summaries kept their double.MinValue and double.MaxValue
+        // initialisers. Reporting it beside the field that caused it is the difference
+        // between a bug report and a fix.
+        if (Problems.Count > 0)
+        {
+            return;
+        }
+
         LastChartData = SuperService.GenerateChartData(Config, Team);
         LastTableData = SuperService.GenerateTableData(Config, Team);
         Navigation.NavigateTo("/chart");

--- a/Services/SupercompensationService.cs
+++ b/Services/SupercompensationService.cs
@@ -51,10 +51,34 @@ public class SupercompensationService
     }
 
     /// <summary>
+    /// Refuses a configuration that cannot produce a meaningful curve, naming the
+    /// offending property and its permitted range.
+    ///
+    /// Throwing is the point. The alternative — guarding the symptom downstream with
+    /// double.IsNaN checks — leaves the 0/0 division in place for the next caller to
+    /// find, and silently returning NaN is exactly the behaviour that made
+    /// SprintDuration = 0 render a blank chart with no error.
+    /// </summary>
+    private static void EnsureUsable(SprintConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var problems = config.Validate();
+        if (problems.Count > 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(config),
+                string.Join(" ", problems));
+        }
+    }
+
+    /// <summary>
     /// Generate full dataset: fine-grained points for smooth chart + discrete daily data.
     /// </summary>
     public ChartDataSet GenerateChartData(SprintConfiguration config, List<TeamMember> team, int pointsPerSprint = 50)
     {
+        EnsureUsable(config);
+
         var teamWeight = CalculateTeamWeight(team);
         var totalDays = config.NumberOfSprints * config.SprintDuration;
         var totalPoints = config.NumberOfSprints * pointsPerSprint;
@@ -130,6 +154,8 @@ public class SupercompensationService
     /// </summary>
     public List<SprintDataPoint> GenerateTableData(SprintConfiguration config, List<TeamMember> team)
     {
+        EnsureUsable(config);
+
         var teamWeight = CalculateTeamWeight(team);
         var points = new List<SprintDataPoint>();
 

--- a/tests/SupercompensationApp.Tests/SprintConfigurationValidationTests.cs
+++ b/tests/SupercompensationApp.Tests/SprintConfigurationValidationTests.cs
@@ -1,0 +1,231 @@
+namespace SupercompensationApp.Tests;
+
+using SupercompensationApp.Models;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// The Konfiguracja tab guards its parameters in the markup only — `min` and `max` on an
+/// &lt;input&gt; are validation HINTS. They do not stop a value being typed or pasted,
+/// and @bind performs no range check of its own.
+///
+/// With SprintDuration = 0, `dayInSprint / config.SprintDuration` is 0/0. Every
+/// deviation becomes NaN; every comparison against NaN is false, so CalculateDeviation
+/// falls through to its final branch and the summaries keep the double.MinValue and
+/// double.MaxValue they were initialised with. The chart renders blank, with no error
+/// anywhere. That silence is what these tests exist to remove.
+/// </summary>
+public class SprintConfigurationValidationTests
+{
+    private static List<TeamMember> Team() =>
+    [
+        new() { Name = "A", Role = "Developer", Weight = 1.0 },
+    ];
+
+    // ── The reported defect ──────────────────────────────────────────────────
+
+    [Fact]
+    public void AZeroSprintDurationCannotReachTheCurve()
+    {
+        var service = new SupercompensationService();
+        var config = new SprintConfiguration { SprintDuration = 0 };
+
+        var chart = Assert.Throws<ArgumentOutOfRangeException>(
+            () => { service.GenerateChartData(config, Team()); });
+        var table = Assert.Throws<ArgumentOutOfRangeException>(
+            () => { service.GenerateTableData(config, Team()); });
+
+        foreach (var thrown in new[] { chart, table })
+        {
+            Assert.True(
+                thrown.Message.Contains(nameof(SprintConfiguration.SprintDuration), StringComparison.Ordinal),
+                $"The failure must name the offending property so the caller can act on " +
+                $"it. Got: {thrown.Message}");
+        }
+    }
+
+    [Fact]
+    public void AZeroSprintCountIsRefusedToo()
+    {
+        var service = new SupercompensationService();
+        var config = new SprintConfiguration { NumberOfSprints = 0 };
+
+        var thrown = Assert.Throws<ArgumentOutOfRangeException>(
+            () => { service.GenerateChartData(config, Team()); });
+
+        Assert.True(
+            thrown.Message.Contains(nameof(SprintConfiguration.NumberOfSprints), StringComparison.Ordinal),
+            $"Got: {thrown.Message}");
+    }
+
+    [Fact]
+    public void NegativeValuesAreRefused()
+    {
+        // A negative sprint count produced a negative sprint index through
+        // Math.Min((int)(day / duration), N - 1), and with it a baseline BELOW the
+        // configured initial one.
+        var service = new SupercompensationService();
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => { service.GenerateChartData(
+                new SprintConfiguration { SprintDuration = -10 }, Team()); });
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => { service.GenerateChartData(
+                new SprintConfiguration { NumberOfSprints = -3 }, Team()); });
+    }
+
+    // ── Every parameter, both directions ─────────────────────────────────────
+
+    [Fact]
+    public void EveryParameterIsRejectedOnBothSidesOfItsRange()
+    {
+        var cases = new (string Property, SprintConfiguration Config)[]
+        {
+            (nameof(SprintConfiguration.SprintDuration),
+                new SprintConfiguration { SprintDuration = SprintConfiguration.MinSprintDuration - 1 }),
+            (nameof(SprintConfiguration.SprintDuration),
+                new SprintConfiguration { SprintDuration = SprintConfiguration.MaxSprintDuration + 1 }),
+            (nameof(SprintConfiguration.NumberOfSprints),
+                new SprintConfiguration { NumberOfSprints = SprintConfiguration.MinNumberOfSprints - 1 }),
+            (nameof(SprintConfiguration.NumberOfSprints),
+                new SprintConfiguration { NumberOfSprints = SprintConfiguration.MaxNumberOfSprints + 1 }),
+            (nameof(SprintConfiguration.BaselineIncrement),
+                new SprintConfiguration { BaselineIncrement = SprintConfiguration.MinBaselineIncrement - 1 }),
+            (nameof(SprintConfiguration.BaselineIncrement),
+                new SprintConfiguration { BaselineIncrement = SprintConfiguration.MaxBaselineIncrement + 1 }),
+            (nameof(SprintConfiguration.InitialBaseline),
+                new SprintConfiguration { InitialBaseline = SprintConfiguration.MinInitialBaseline - 1 }),
+            (nameof(SprintConfiguration.InitialBaseline),
+                new SprintConfiguration { InitialBaseline = SprintConfiguration.MaxInitialBaseline + 1 }),
+            (nameof(SprintConfiguration.FatigueDepth),
+                new SprintConfiguration { FatigueDepth = SprintConfiguration.MinFatigueDepth - 1 }),
+            (nameof(SprintConfiguration.FatigueDepth),
+                new SprintConfiguration { FatigueDepth = SprintConfiguration.MaxFatigueDepth + 1 }),
+            (nameof(SprintConfiguration.SupercompensationPeak),
+                new SprintConfiguration { SupercompensationPeak = SprintConfiguration.MinSupercompensationPeak - 1 }),
+            (nameof(SprintConfiguration.SupercompensationPeak),
+                new SprintConfiguration { SupercompensationPeak = SprintConfiguration.MaxSupercompensationPeak + 1 }),
+        };
+
+        foreach (var (property, config) in cases)
+        {
+            var problems = config.Validate();
+
+            Assert.True(
+                problems.Count == 1,
+                $"{property} out of range should report exactly one problem, got " +
+                $"{problems.Count}: {string.Join(" | ", problems)}");
+
+            Assert.True(
+                problems[0].Contains(property, StringComparison.Ordinal),
+                $"The message must name {property}. Got: {problems[0]}");
+        }
+    }
+
+    [Fact]
+    public void TheBoundaryValuesThemselvesAreAccepted()
+    {
+        // An off-by-one in a validator is as much a defect as no validator: the ranges
+        // are inclusive, and a reader who types the maximum the UI advertises must not
+        // be told it is out of range.
+        var boundaries = new[]
+        {
+            new SprintConfiguration
+            {
+                SprintDuration = SprintConfiguration.MinSprintDuration,
+                NumberOfSprints = SprintConfiguration.MinNumberOfSprints,
+                BaselineIncrement = SprintConfiguration.MinBaselineIncrement,
+                InitialBaseline = SprintConfiguration.MinInitialBaseline,
+                FatigueDepth = SprintConfiguration.MinFatigueDepth,
+                SupercompensationPeak = SprintConfiguration.MinSupercompensationPeak,
+            },
+            new SprintConfiguration
+            {
+                SprintDuration = SprintConfiguration.MaxSprintDuration,
+                NumberOfSprints = SprintConfiguration.MaxNumberOfSprints,
+                BaselineIncrement = SprintConfiguration.MaxBaselineIncrement,
+                InitialBaseline = SprintConfiguration.MaxInitialBaseline,
+                FatigueDepth = SprintConfiguration.MaxFatigueDepth,
+                SupercompensationPeak = SprintConfiguration.MaxSupercompensationPeak,
+            },
+        };
+
+        foreach (var config in boundaries)
+        {
+            var problems = config.Validate();
+            Assert.True(
+                problems.Count == 0,
+                $"Every range is inclusive, so its endpoints must be accepted. Got: " +
+                $"{string.Join(" | ", problems)}");
+        }
+    }
+
+    [Fact]
+    public void NaNAndInfinityAreRefusedRatherThanSlippingThrough()
+    {
+        // Worth its own test because it is the trap in writing the check. A NaN fails
+        // EVERY comparison, so `value < min || value > max` is false for NaN and would
+        // wave it through into exactly the arithmetic this validation exists to prevent.
+        foreach (var bad in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
+        {
+            var config = new SprintConfiguration { FatigueDepth = bad };
+            var problems = config.Validate();
+
+            Assert.True(
+                problems.Count == 1,
+                $"FatigueDepth = {bad} must be refused; the range test has to be written " +
+                $"as 'not inside' rather than 'outside', because NaN fails both " +
+                $"comparisons. Got {problems.Count} problems.");
+        }
+    }
+
+    // ── Nothing inside the accepted range produces NaN ────────────────────────
+
+    [Fact]
+    public void NoAcceptedConfigurationCanProduceANonFiniteNumber()
+    {
+        // The point of the whole issue: for anything the validator lets through, every
+        // number the chart and the table carry is finite.
+        var service = new SupercompensationService();
+        var team = Team();
+
+        foreach (var duration in new[] { 5, 7, 10, 13, 30 })
+        {
+            foreach (var sprints in new[] { 1, 2, 5, 20 })
+            {
+                var config = new SprintConfiguration
+                {
+                    SprintDuration = duration,
+                    NumberOfSprints = sprints,
+                };
+
+                Assert.True(config.Validate().Count == 0, "Sweep configuration must be valid.");
+
+                var chart = service.GenerateChartData(config, team);
+                var table = service.GenerateTableData(config, team);
+
+                var values = chart.Performance
+                    .Concat(chart.Baselines)
+                    .Concat(chart.Days)
+                    .Concat(chart.Summaries.SelectMany(s => new[]
+                    {
+                        s.Baseline, s.PeakPerformance, s.MinPerformance, s.DeliveryValue,
+                    }))
+                    .Concat(table.SelectMany(t => new[]
+                    {
+                        t.Baseline, t.Deviation, t.Performance,
+                    }));
+
+                foreach (var value in values)
+                {
+                    Assert.True(
+                        double.IsFinite(value),
+                        $"{duration}-day x {sprints} sprints produced {value}, which is " +
+                        $"not finite. An accepted configuration must never yield NaN or " +
+                        $"an infinity — that is what the validation is for.");
+                }
+            }
+        }
+    }
+}

--- a/tests/SupercompensationApp.Tests/SprintConfigurationValidationTests.cs
+++ b/tests/SupercompensationApp.Tests/SprintConfigurationValidationTests.cs
@@ -67,12 +67,18 @@ public class SprintConfigurationValidationTests
         var service = new SupercompensationService();
 
         Assert.Throws<ArgumentOutOfRangeException>(
-            () => { service.GenerateChartData(
-                new SprintConfiguration { SprintDuration = -10 }, Team()); });
+            () =>
+            {
+                service.GenerateChartData(
+                new SprintConfiguration { SprintDuration = -10 }, Team());
+            });
 
         Assert.Throws<ArgumentOutOfRangeException>(
-            () => { service.GenerateChartData(
-                new SprintConfiguration { NumberOfSprints = -3 }, Team()); });
+            () =>
+            {
+                service.GenerateChartData(
+                new SprintConfiguration { NumberOfSprints = -3 }, Team());
+            });
     }
 
     // ── Every parameter, both directions ─────────────────────────────────────

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -351,6 +351,31 @@ html, body {
     height: 100% !important;
 }
 
+/* Out-of-range sprint parameters, listed beside the button they disable.
+   The HTML min/max attributes on the inputs are hints only — they do not stop a value
+   being typed or pasted, and @bind performs no range check — so this is where the
+   reader actually finds out. */
+.validation-errors {
+    list-style: none;
+    margin: 0 0 1rem 0;
+    padding: 0.75rem 1rem;
+    background: rgba(239, 68, 68, 0.12);
+    border-left: 3px solid var(--accent-red);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    text-align: left;
+}
+
+.validation-errors li + li {
+    margin-top: 0.35rem;
+}
+
+.btn-generate:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .no-data {
     text-align: center;
     padding: 4rem 2rem;


### PR DESCRIPTION
Closes #11

## What changed

- `Models/SprintModels.cs` — `SprintConfiguration` owns the ranges and a `Validate()`.
- `Services/SupercompensationService.cs` — both generators refuse an unusable config.
- `Pages/Index.razor` + `app.css` — the failure is reported beside the offending fields
  and disables the button.
- `tests/…/SprintConfigurationValidationTests.cs` — six tests.

## The defect

`min` and `max` on an `<input>` are validation **hints**. They do not stop a value being
typed or pasted, and `@bind` performs no range check of its own — there is no `EditForm`,
no `DataAnnotationsValidator` and no clamp anywhere.

With `SprintDuration = 0`:

```csharp
var normalizedDay = dayInSprint / config.SprintDuration;   // 0 / 0 → NaN
```

`CalculateDeviation(NaN, …)` takes the **final** branch — every comparison against NaN is
false — and returns `NaN`. The summaries keep the `double.MinValue` / `double.MaxValue`
they were initialised with, Chart.js receives an array of nulls, and the page renders a
blank chart **with no error anywhere**.

`NumberOfSprints = 0` is a second path to the same silence. A negative count is a third:
`Math.Min((int)(day / duration), N - 1)` yields a negative sprint index and a baseline
*below* the configured initial one.

## The one subtle thing here

The range test is written as **"not inside"** rather than "outside", and that is not a
style preference:

```csharp
if (!(value >= min && value <= max))
```

A NaN fails **every** comparison. `value < min || value > max` is `false` for NaN, so the
obvious spelling would wave NaN straight through into the arithmetic this validation
exists to prevent. It has its own test, over `NaN`, `+∞` and `−∞`.

## Refusing, not guarding the symptom

Both generators throw `ArgumentOutOfRangeException` naming the property and its permitted
range. The issue is explicit that scattering `double.IsNaN` checks downstream is the wrong
fix — it leaves the division in place for the next caller to find, and silently returning
`NaN` is exactly what made this invisible for as long as it was.

In the UI, `GenerateChart` now reports the problem where the user is rather than
navigating to a blank chart.

## Two tests beyond the obvious

**The boundary values are asserted to be _accepted_.** An off-by-one in a validator is as
much a defect as no validator, and a reader who types the maximum the UI advertises must
not be told it is out of range. Both the all-minimum and all-maximum configurations are
checked.

**A sweep asserts no accepted configuration can produce a non-finite number** — 20
combinations across 5 durations and 4 sprint counts, over every value in the chart, the
summaries and the table. That is the actual claim the validation makes; the individual
rejections are only how it is enforced.

## Verified before pushing

The range logic was simulated against an independent implementation:

```
12 out-of-range cases    → each reports exactly 1 problem, naming the right property
NaN, +Inf, -Inf          → each refused
all-minimum config       → valid
all-maximum config       → valid
defaults                 → valid
```

The `Assert.Throws` lambdas are written with statement bodies on purpose: a
value-returning lambda binds xUnit's `Func<object>` overload, which is marked obsolete,
and `TreatWarningsAsErrors` (added in #6) would turn that into a build failure.

## A note that feeds #16

While adding the range constants I documented something in `SprintConfiguration` that
#16 will need: `FatiguePhaseEnd` and `RecoveryPhaseEnd` are expression-bodied with **no
setter**. The 50% / 80% split is a fixed constant of this model, not a parameter — but the
README's table presents it alongside `D` and `P` as though it were a knob.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_