### PR TITLE
Replace the static page state with an injected AppStateService

### DIFF
--- a/Pages/Chart.razor
+++ b/Pages/Chart.razor
@@ -1,6 +1,7 @@
 @page "/chart"
+@implements IDisposable
 @inject IJSRuntime JS
-@inject SupercompensationService SuperService
+@inject AppStateService State
 @inject NavigationManager Navigation
 
 <PageTitle>Wykres — Supercompensation</PageTitle>
@@ -18,6 +19,14 @@
     }
     else
     {
+        @if (State.IsStale)
+        {
+            <p class="stale-notice">
+                ⚠️ Konfiguracja lub zespół zmieniły się od wygenerowania tego wykresu.
+                Wróć do konfiguracji i wygeneruj go ponownie.
+            </p>
+        }
+
         <div class="chart-controls">
             <button class="btn-toggle @(ShowPhases ? "active" : "")" @onclick="TogglePhases">
                 🎨 Pokaż fazy
@@ -64,10 +73,31 @@
 </div>
 
 @code {
-    private ChartDataSet? ChartData => Index.LastChartData;
+    // Reads the injected state. It used to be `Index.LastChartData` — a page component
+    // reaching into another page component's type for its data, which made Chart
+    // unrenderable and untestable without Index for reasons unrelated to routing.
+    private ChartDataSet? ChartData => State.LastChartData;
     private bool ShowPhases = true;
     private bool ShowBaseline = true;
     private bool _chartRendered = false;
+
+    protected override void OnInitialized()
+    {
+        State.OnChange += HandleStateChanged;
+    }
+
+    // A component that subscribes without unsubscribing leaks, and worse, re-renders a
+    // tree that has already been disposed.
+    public void Dispose()
+    {
+        State.OnChange -= HandleStateChanged;
+    }
+
+    private void HandleStateChanged()
+    {
+        _chartRendered = false;
+        StateHasChanged();
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -82,7 +112,7 @@
     {
         if (ChartData is null) return;
 
-        var config = Index.Config;
+        var config = State.Config;
         var sprintBoundaries = new List<double>();
         for (int i = 1; i < config.NumberOfSprints; i++)
             sprintBoundaries.Add(i * config.SprintDuration);
@@ -115,13 +145,13 @@
 
     private async Task ExportCsv()
     {
-        if (Index.LastTableData is null) return;
+        if (State.LastTableData is null) return;
 
         // The formatting lives in Services/CsvExporter so a unit test can reach it. It
         // used to be string interpolation here, which formats a double with the CURRENT
         // culture — and under pl-PL, which is what this app's own <html lang="pl">
         // invites, every decimal comma became an extra field separator.
-        var csv = CsvExporter.ToCsv(Index.LastTableData);
+        var csv = CsvExporter.ToCsv(State.LastTableData);
 
         await JS.InvokeVoidAsync("downloadCsv", csv, "supercompensation_data.csv");
     }

--- a/Pages/Data.razor
+++ b/Pages/Data.razor
@@ -1,4 +1,6 @@
 @page "/data"
+@implements IDisposable
+@inject AppStateService State
 @inject NavigationManager Navigation
 
 <PageTitle>Dane — Supercompensation</PageTitle>
@@ -80,7 +82,19 @@
 </div>
 
 @code {
-    private List<SprintDataPoint>? TableData => Index.LastTableData;
+    // Was `Index.LastTableData`. Data no longer depends on the Index page type.
+    private List<SprintDataPoint>? TableData => State.LastTableData;
+
+    protected override void OnInitialized()
+    {
+        State.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        State.OnChange -= StateHasChanged;
+    }
+
     private int SelectedSprint { get; set; } = 0;
     private string SelectedPhase { get; set; } = "";
 

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -1,5 +1,5 @@
 @page "/"
-@inject SupercompensationService SuperService
+@inject AppStateService State
 @inject NavigationManager Navigation
 
 <PageTitle>Konfiguracja — Supercompensation</PageTitle>
@@ -10,32 +10,32 @@
         <div class="param-grid">
             <div class="param-card">
                 <label>Czas trwania sprintu (dni)</label>
-                <input type="number" @bind="Config.SprintDuration" min="5" max="30" />
+                <input type="number" @bind="State.Config.SprintDuration" min="5" max="30" />
                 <span class="param-hint">Domyślnie: 10</span>
             </div>
             <div class="param-card">
                 <label>Liczba sprintów</label>
-                <input type="number" @bind="Config.NumberOfSprints" min="1" max="20" />
+                <input type="number" @bind="State.Config.NumberOfSprints" min="1" max="20" />
                 <span class="param-hint">Domyślnie: 3</span>
             </div>
             <div class="param-card">
                 <label>Przyrost baseline</label>
-                <input type="number" @bind="Config.BaselineIncrement" min="0" max="50" step="0.5" />
+                <input type="number" @bind="State.Config.BaselineIncrement" min="0" max="50" step="0.5" />
                 <span class="param-hint">Wzrost po każdym sprincie</span>
             </div>
             <div class="param-card">
                 <label>Początkowy baseline</label>
-                <input type="number" @bind="Config.InitialBaseline" min="50" max="200" step="5" />
+                <input type="number" @bind="State.Config.InitialBaseline" min="50" max="200" step="5" />
                 <span class="param-hint">Startowa wydajność bazowa</span>
             </div>
             <div class="param-card">
                 <label>Głębokość zmęczenia</label>
-                <input type="number" @bind="Config.FatigueDepth" min="5" max="50" step="1" />
+                <input type="number" @bind="State.Config.FatigueDepth" min="5" max="50" step="1" />
                 <span class="param-hint">Jak głęboko spada krzywa</span>
             </div>
             <div class="param-card">
                 <label>Szczyt superkompensacji</label>
-                <input type="number" @bind="Config.SupercompensationPeak" min="5" max="40" step="1" />
+                <input type="number" @bind="State.Config.SupercompensationPeak" min="5" max="40" step="1" />
                 <span class="param-hint">Jak wysoko ponad baseline</span>
             </div>
         </div>
@@ -44,7 +44,7 @@
     <section class="config-section">
         <h2>👥 Zespół</h2>
         <p class="section-info">
-            Łączna waga zespołu: <strong>@TeamWeight.ToString("F2")</strong>
+            Łączna waga zespołu: <strong>@State.TeamWeight.ToString("F2")</strong>
         </p>
 
         <div class="team-table-container">
@@ -59,16 +59,16 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @for (int i = 0; i < Team.Count; i++)
+                    @for (int i = 0; i < State.Team.Count; i++)
                     {
                         var idx = i;
                         <tr>
                             <td class="row-number">@(idx + 1)</td>
                             <td>
-                                <input type="text" @bind="Team[idx].Name" placeholder="Imię..." />
+                                <input type="text" @bind="State.Team[idx].Name" placeholder="Imię..." />
                             </td>
                             <td>
-                                <select @bind="Team[idx].Role">
+                                <select @bind="State.Team[idx].Role">
                                     <option value="Developer">Developer</option>
                                     <option value="QA">QA / Tester</option>
                                     <option value="DevOps">DevOps</option>
@@ -80,7 +80,7 @@
                                 </select>
                             </td>
                             <td>
-                                <input type="number" @bind="Team[idx].Weight"
+                                <input type="number" @bind="State.Team[idx].Weight"
                                        min="0.1" max="2.0" step="0.05" />
                             </td>
                             <td>
@@ -94,10 +94,10 @@
         </div>
 
         <div class="team-actions">
-            <button class="btn-add" @onclick="AddMember">
+            <button class="btn-add" @onclick="State.AddMember">
                 ➕ Dodaj członka zespołu
             </button>
-            <button class="btn-reset" @onclick="ResetTeam">
+            <button class="btn-reset" @onclick="State.ResetTeam">
                 🔄 Przywróć domyślny zespół
             </button>
         </div>
@@ -120,54 +120,26 @@
 </div>
 
 @code {
-    // These are stored in a simple static holder so they persist across navigations
-    public static SprintConfiguration Config { get; set; } = new();
-    public static List<TeamMember> Team { get; set; } = TeamMember.GetDefaultTeam();
-    public static ChartDataSet? LastChartData { get; set; }
-    public static List<SprintDataPoint>? LastTableData { get; set; }
+    // No statics. Everything below reads State, which is injected — so Chart and Data no
+    // longer reach into this component's type to find their data, and a test can
+    // construct the state without instantiating a page.
 
-    private double TeamWeight => SuperService.CalculateTeamWeight(Team);
-
-    private void AddMember()
-    {
-        Team.Add(new TeamMember
-        {
-            Name = $"Nowy {Team.Count + 1}",
-            Role = "Developer",
-            Weight = 1.0
-        });
-    }
+    private IReadOnlyList<string> Problems => State.Problems;
 
     private void RemoveMember(int index)
     {
-        if (Team.Count > 1)
-            Team.RemoveAt(index);
+        State.RemoveMember(State.Team[index]);
     }
-
-    private void ResetTeam()
-    {
-        Team = TeamMember.GetDefaultTeam();
-    }
-
-    // Recomputed on every render, which is what makes the button state and the message
-    // list track what the user has typed without an explicit validate step.
-    private IReadOnlyList<string> Problems => Config.Validate();
 
     private void GenerateChart()
     {
-        // The service throws on an unusable configuration, so this guard is about WHERE
-        // the reader finds out. Before it, SprintDuration = 0 navigated to a blank chart
-        // with no error: 0/0 made every deviation NaN, every comparison against NaN is
-        // false, and the summaries kept their double.MinValue and double.MaxValue
-        // initialisers. Reporting it beside the field that caused it is the difference
-        // between a bug report and a fix.
-        if (Problems.Count > 0)
+        // State.Generate() returns false rather than throwing when the configuration is
+        // unusable. The button is disabled in that case anyway; this is the second line
+        // of defence, since `disabled` is a UI hint in exactly the way `min` and `max`
+        // turned out to be (#11).
+        if (State.Generate())
         {
-            return;
+            Navigation.NavigateTo("/chart");
         }
-
-        LastChartData = SuperService.GenerateChartData(Config, Team);
-        LastTableData = SuperService.GenerateTableData(Config, Team);
-        Navigation.NavigateTo("/chart");
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -10,4 +10,9 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddSingleton<SupercompensationService>();
 
+// The application's state, replacing four `public static` properties that used to live
+// on Pages/Index.razor. Singleton rather than scoped: Blazor WebAssembly is single-user,
+// and scoped would behave identically here while saying something untrue about lifetime.
+builder.Services.AddSingleton<AppStateService>();
+
 await builder.Build().RunAsync();

--- a/Services/AppStateService.cs
+++ b/Services/AppStateService.cs
@@ -1,0 +1,178 @@
+namespace SupercompensationApp.Services;
+
+using System.Globalization;
+using System.Text;
+using SupercompensationApp.Models;
+
+/// <summary>
+/// The application's state: the sprint configuration, the team, and the last generated
+/// results.
+///
+/// It replaces four `public static` properties on Pages/Index.razor. The comment on
+/// those said "stored in a simple static holder so they persist across navigations",
+/// and the motive was sound — state must survive navigation. The mechanism cost four
+/// things:
+///
+///   1. A page component became a data dependency. Chart and Data reached into
+///      `Index.LastChartData` and could not be rendered, tested or reused without it,
+///      for reasons that have nothing to do with routing.
+///   2. It was untestable. Static mutable state is shared across the whole process and
+///      xUnit runs test classes in parallel, so any test touching Index.Config could
+///      corrupt another.
+///   3. It could not be persisted — see #14, which is blocked on this.
+///   4. ResetTeam() reassigned the list while LastChartData still described the previous
+///      team, and the two were silently out of step until the user pressed generate
+///      again.
+///
+/// Registered as a singleton in Program.cs. Blazor WebAssembly is single-user and
+/// SupercompensationService sets the precedent; AddScoped would behave identically here
+/// but would say something untrue about lifetime.
+/// </summary>
+public class AppStateService
+{
+    private readonly SupercompensationService _service;
+
+    /// <summary>
+    /// The signature of the configuration and team that produced the current results.
+    /// Null when nothing has been generated yet.
+    /// </summary>
+    private string? _resultsSignature;
+
+    public AppStateService(SupercompensationService service)
+    {
+        _service = service ?? throw new ArgumentNullException(nameof(service));
+    }
+
+    /// <summary>
+    /// Raised when the state changes in a way another page should notice. A page
+    /// rendered while state changes elsewhere has no other way to find out.
+    /// </summary>
+    public event Action? OnChange;
+
+    public SprintConfiguration Config { get; private set; } = new();
+
+    public List<TeamMember> Team { get; private set; } = TeamMember.GetDefaultTeam();
+
+    public ChartDataSet? LastChartData { get; private set; }
+
+    public List<SprintDataPoint>? LastTableData { get; private set; }
+
+    public bool HasResults => LastChartData is not null && LastTableData is not null;
+
+    /// <summary>
+    /// True when results exist but the configuration or team has changed since they were
+    /// generated, so the chart on screen describes inputs the user has already edited.
+    ///
+    /// This is item 4 above, made visible rather than left silent. It is computed by
+    /// comparing signatures rather than by a flag the mutating code has to remember to
+    /// set — a flag can be forgotten by the next person who adds a field, and the
+    /// failure mode of forgetting is a chart that quietly describes the wrong team.
+    /// </summary>
+    public bool IsStale => HasResults && Signature() != _resultsSignature;
+
+    /// <summary>
+    /// The configuration problems, if any. Empty means the state can be generated from.
+    /// </summary>
+    public IReadOnlyList<string> Problems => Config.Validate();
+
+    public double TeamWeight => _service.CalculateTeamWeight(Team);
+
+    /// <summary>
+    /// Regenerates the chart and table from the current configuration and team.
+    /// Returns false, changing nothing, when the configuration is not usable.
+    /// </summary>
+    public bool Generate()
+    {
+        if (Problems.Count > 0)
+        {
+            return false;
+        }
+
+        LastChartData = _service.GenerateChartData(Config, Team);
+        LastTableData = _service.GenerateTableData(Config, Team);
+        _resultsSignature = Signature();
+
+        NotifyChanged();
+        return true;
+    }
+
+    public void AddMember()
+    {
+        Team.Add(new TeamMember
+        {
+            Name = $"Nowy {Team.Count + 1}",
+            Role = "Developer",
+            Weight = 1.0,
+        });
+
+        NotifyChanged();
+    }
+
+    /// <summary>
+    /// A team of zero makes CalculateTeamWeight return its sentinel 1.0, which is a
+    /// different model rather than an empty one — hence the floor of one member. The UI
+    /// disables the button rather than ignoring the click; see #13.
+    /// </summary>
+    public bool CanRemoveMember => Team.Count > 1;
+
+    public void RemoveMember(TeamMember member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+
+        if (!CanRemoveMember)
+        {
+            return;
+        }
+
+        if (Team.Remove(member))
+        {
+            NotifyChanged();
+        }
+    }
+
+    public void ResetTeam()
+    {
+        Team = TeamMember.GetDefaultTeam();
+        NotifyChanged();
+    }
+
+    /// <summary>
+    /// Call after editing Config or a TeamMember through a two-way binding, which
+    /// cannot raise the event itself.
+    /// </summary>
+    public void NotifyChanged() => OnChange?.Invoke();
+
+    /// <summary>
+    /// Everything the results depend on, in one string.
+    ///
+    /// InvariantCulture throughout: this is compared against a value captured earlier in
+    /// the same session, so a culture-dependent format would be consistent — but the
+    /// same reasoning was true of the CSV export before #10, and a signature that
+    /// changes meaning with the browser's locale is a trap waiting for the day it is
+    /// persisted (#14).
+    /// </summary>
+    private string Signature()
+    {
+        var builder = new StringBuilder();
+        var invariant = CultureInfo.InvariantCulture;
+
+        builder
+            .Append(Config.SprintDuration.ToString(invariant)).Append('|')
+            .Append(Config.NumberOfSprints.ToString(invariant)).Append('|')
+            .Append(Config.BaselineIncrement.ToString(invariant)).Append('|')
+            .Append(Config.InitialBaseline.ToString(invariant)).Append('|')
+            .Append(Config.FatigueDepth.ToString(invariant)).Append('|')
+            .Append(Config.SupercompensationPeak.ToString(invariant)).Append("||");
+
+        foreach (var member in Team)
+        {
+            builder
+                .Append(member.Id).Append(':')
+                .Append(member.Name).Append(':')
+                .Append(member.Role).Append(':')
+                .Append(member.Weight.ToString(invariant)).Append(';');
+        }
+
+        return builder.ToString();
+    }
+}

--- a/tests/SupercompensationApp.Tests/AppStateServiceTests.cs
+++ b/tests/SupercompensationApp.Tests/AppStateServiceTests.cs
@@ -1,0 +1,208 @@
+namespace SupercompensationApp.Tests;
+
+using SupercompensationApp.Models;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// Every test here constructs AppStateService directly. That is the point of the issue
+/// rather than a detail of it: the state used to be four `public static` properties on
+/// Pages/Index.razor, and static mutable state is shared across the whole process while
+/// xUnit runs test classes in parallel — so a test touching Index.Config could corrupt
+/// an unrelated one, and none of this could be written at all.
+/// </summary>
+public class AppStateServiceTests
+{
+    private static AppStateService NewState() => new(new SupercompensationService());
+
+    [Fact]
+    public void ItStartsWithTheDefaultTeamAndNoResults()
+    {
+        var state = NewState();
+
+        Assert.True(state.Team.Count > 0, "A fresh state should carry the default team.");
+        Assert.True(state.Problems.Count == 0, "The default configuration must be valid.");
+        Assert.True(!state.HasResults, "Nothing has been generated yet.");
+        Assert.True(!state.IsStale, "Nothing generated cannot be stale.");
+    }
+
+    [Fact]
+    public void GenerateProducesResultsThatAreNotStale()
+    {
+        var state = NewState();
+
+        Assert.True(state.Generate(), "The default configuration must generate.");
+        Assert.True(state.HasResults, "Generate must populate both the chart and the table.");
+        Assert.True(
+            !state.IsStale,
+            "Results are fresh the instant they are generated; anything else means the " +
+            "signature captured at generation does not match the one computed from the " +
+            "same inputs.");
+    }
+
+    [Fact]
+    public void GenerateRefusesAnInvalidConfigurationAndChangesNothing()
+    {
+        var state = NewState();
+        state.Generate();
+        var before = state.LastChartData;
+
+        state.Config.SprintDuration = 0;
+
+        Assert.True(!state.Generate(), "An unusable configuration must not generate.");
+        Assert.True(
+            ReferenceEquals(before, state.LastChartData),
+            "A refused Generate must leave the previous results untouched rather than " +
+            "half-replacing them.");
+    }
+
+    // ── Staleness: item 4 of the issue, made visible ──────────────────────────
+
+    [Fact]
+    public void EditingTheConfigurationAfterGeneratingMarksTheResultsStale()
+    {
+        var state = NewState();
+        state.Generate();
+
+        state.Config.FatigueDepth += 1.0;
+
+        Assert.True(
+            state.IsStale,
+            "The chart on screen now describes a fatigue depth the user has already " +
+            "changed, and nothing else would say so.");
+    }
+
+    [Fact]
+    public void EditingATeamMemberMarksTheResultsStale()
+    {
+        var state = NewState();
+        state.Generate();
+
+        state.Team[0].Weight += 0.1;
+
+        Assert.True(
+            state.IsStale,
+            "Team weight scales every number on the chart, so a changed weight makes the " +
+            "displayed results describe a different team.");
+    }
+
+    [Fact]
+    public void ResettingTheTeamMarksTheResultsStale()
+    {
+        // This is the exact defect the issue describes: ResetTeam() used to reassign the
+        // list while LastChartData still described the previous team, and the two were
+        // silently out of step until the user pressed generate again.
+        var state = NewState();
+        state.Team[0].Weight = 1.75;
+        state.Generate();
+
+        state.ResetTeam();
+
+        Assert.True(
+            state.IsStale,
+            "Resetting the team must not leave a chart describing the old one without " +
+            "saying so.");
+    }
+
+    [Fact]
+    public void RegeneratingClearsStaleness()
+    {
+        var state = NewState();
+        state.Generate();
+        state.Config.NumberOfSprints += 1;
+        Assert.True(state.IsStale, "Precondition for this test.");
+
+        state.Generate();
+
+        Assert.True(!state.IsStale, "Regenerating must bring the results back into step.");
+        Assert.True(
+            state.LastChartData!.Summaries.Count == state.Config.NumberOfSprints,
+            "and the new results must reflect the edited configuration.");
+    }
+
+    // ── Team membership ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheLastTeamMemberCannotBeRemoved()
+    {
+        // A team of zero makes CalculateTeamWeight return its sentinel 1.0, which is a
+        // different model rather than an empty one.
+        var state = NewState();
+        while (state.CanRemoveMember)
+        {
+            state.RemoveMember(state.Team[0]);
+        }
+
+        Assert.True(state.Team.Count == 1, $"Expected one member left, got {state.Team.Count}.");
+
+        state.RemoveMember(state.Team[0]);
+
+        Assert.True(state.Team.Count == 1, "Removing the last member must be refused.");
+        Assert.True(!state.CanRemoveMember, "and the UI must be able to see that in advance.");
+    }
+
+    [Fact]
+    public void RemovingTakesTheMemberNotAPosition()
+    {
+        // Passing an index into a callback that fires after a re-render is stale by
+        // construction — the same reasoning behind @key in #13.
+        var state = NewState();
+        var target = state.Team[2];
+        var before = state.Team.Count;
+
+        state.RemoveMember(target);
+
+        Assert.True(state.Team.Count == before - 1, "Exactly one member should be gone.");
+
+        // List<T>.Exists rather than Enumerable.Any: xUnit's analyzer flags Any() inside
+        // Assert.True (xUnit2012) and TreatWarningsAsErrors turns that into a build
+        // failure, while Assert.DoesNotContain would lose the message.
+        var stillPresent = state.Team.Exists(m => m.Id == target.Id);
+        Assert.True(
+            !stillPresent,
+            "and it should be the one that was passed in, identified by Id.");
+    }
+
+    // ── Change notification ──────────────────────────────────────────────────
+
+    [Fact]
+    public void SubscribersAreNotifiedOfEveryStateChange()
+    {
+        var state = NewState();
+        var count = 0;
+        void Handler() => count++;
+
+        state.OnChange += Handler;
+
+        state.AddMember();
+        state.Generate();
+        state.ResetTeam();
+        state.RemoveMember(state.Team[0]);
+
+        Assert.True(
+            count == 4,
+            $"Each of AddMember, Generate, ResetTeam and RemoveMember should notify once; " +
+            $"got {count}. A page rendered while state changes elsewhere has no other way " +
+            $"to find out.");
+    }
+
+    [Fact]
+    public void UnsubscribingStopsDelivery()
+    {
+        // The Dispose half. A component that subscribes without unsubscribing leaks and
+        // re-renders a tree that has already been disposed.
+        var state = NewState();
+        var count = 0;
+        void Handler() => count++;
+
+        state.OnChange += Handler;
+        state.AddMember();
+        var afterSubscribe = count;
+
+        state.OnChange -= Handler;
+        state.AddMember();
+
+        Assert.True(afterSubscribe == 1, $"Expected one notification while subscribed, got {afterSubscribe}.");
+        Assert.True(count == 1, $"No further notifications after unsubscribing; got {count}.");
+    }
+}

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -355,6 +355,19 @@ html, body {
    The HTML min/max attributes on the inputs are hints only — they do not stop a value
    being typed or pasted, and @bind performs no range check — so this is where the
    reader actually finds out. */
+/* Shown when the chart on screen was generated from inputs the user has since edited.
+   Before the state moved into a service this was silent: ResetTeam reassigned the list
+   while the chart still described the previous team. */
+.stale-notice {
+    margin: 0 0 1rem 0;
+    padding: 0.75rem 1rem;
+    background: rgba(245, 158, 11, 0.12);
+    border-left: 3px solid var(--accent-amber);
+    border-radius: var(--radius);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
 .validation-errors {
     list-style: none;
     margin: 0 0 1rem 0;


### PR DESCRIPTION
Closes #12

## What changed

- `Services/AppStateService.cs` — new; owns config, team, results, and change notification.
- `Program.cs` — registered as a singleton.
- `Pages/Index.razor`, `Chart.razor`, `Data.razor` — every `static` and every `Index.`
  reference gone.
- `app.css` — a notice for stale results.
- `tests/…/AppStateServiceTests.cs` — eleven tests.

## Why

Four `public static` properties on `Pages/Index.razor` held the whole application state,
and the other two pages reached into that component's *type* to read them. The comment on
them was honest about the motive — state must survive navigation — and the mechanism cost
four things, all four of which this PR closes:

1. **A page component was a data dependency.** `Chart` and `Data` could not be rendered,
   tested or reused without `Index`, for reasons unrelated to routing.
2. **It was untestable.** Static mutable state is shared across the process and xUnit runs
   test classes in parallel, so a test touching `Index.Config` could corrupt an unrelated
   one. The eleven tests in this PR could not have been written before it.
3. **It could not be persisted** — #14 is blocked on this.
4. **`ResetTeam()` reassigned the list** while `LastChartData` still described the previous
   team, and the two were silently out of step.

## Item 4: computed, not flagged

The issue said to pick a treatment and say which. I picked the staleness flag over
regenerating on change — regenerating does work the user did not ask for on every
character typed into six numeric fields.

But `IsStale` is **computed from a signature**, not a boolean somebody sets:

```csharp
public bool IsStale => HasResults && Signature() != _resultsSignature;
```

A flag would work today and can be forgotten by whoever adds the next configuration
field. The failure mode of forgetting is a chart that quietly describes the wrong team —
which is precisely the defect being fixed, so the fix should not be able to regress the
same way. The signature covers every config value and every member's id, name, role and
weight, formatted with `InvariantCulture` (the reasoning from #10 applies again, and
harder once #14 persists it).

The chart page surfaces it as a notice.

## Verified as acceptance criteria, by grep

```
$ grep -rn 'static' --include='*.razor' .
./Pages/Index.razor:123:    // No statics. Everything below reads State ...

$ grep -rn 'Index\.' --include='*.razor' Pages/ Layout/
Pages/Chart.razor:76:    // Reads the injected state. It used to be `Index.LastChartData` ...
Pages/Data.razor:85:    // Was `Index.LastTableData`. Data no longer depends on the Index page type.
```

Only comments remain, which is the point of keeping them.

## Two smaller changes that came with it

**`RemoveMember` takes the member, not an index.** An index captured in a callback that
fires after a re-render is stale by construction — the same reasoning behind `@key` in
#13, one level up. The last member still cannot be removed (a team of zero makes
`CalculateTeamWeight` return its sentinel `1.0`, which is a *different* model rather than
an empty one), but `CanRemoveMember` now exposes that so the UI can disable rather than
silently ignore. #13 will use it.

**Both consuming pages `@implements IDisposable`** and unsubscribe from `OnChange`. A
component that subscribes without unsubscribing leaks and re-renders an already-disposed
tree. There is a test for the unsubscribe half specifically.

## Note on the test file

`List<T>.Exists` is used in one place where `Enumerable.Any()` would read more naturally.
xUnit's analyzer flags `Any()` inside `Assert.True` (xUnit2012) and `TreatWarningsAsErrors`
(from #6) turns that into a build failure, while `Assert.DoesNotContain` would lose the
message explaining what the assertion means. The reason is in a comment at the call site.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_