### PR TITLE
Key the team rows by TeamMember.Id and bind to the member

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -59,16 +59,36 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @for (int i = 0; i < State.Team.Count; i++)
+                    @* Keyed by TeamMember.Id, and bound to the member rather than to
+                       Team[index].
+
+                       Without @key, Blazor's diff matches rendered elements to the
+                       previous render BY POSITION. Remove the member at index 2 of seven
+                       and every row below shifts up one, so the renderer keeps the
+                       existing <input> elements where they are and rewrites their values
+                       against the NEW occupant of each position.
+
+                       @bind on a text input commits on blur, so the concrete loss was:
+                       type a name into row 5, click the remove button on row 2 without
+                       leaving the field first, and the pending value is committed against
+                       whichever member has moved into position 5. Element state Blazor
+                       does not own — caret position, native validation state, an open
+                       <select> — follows the DOM node rather than the model for the same
+                       reason.
+
+                       TeamMember.Id already existed for exactly this and was generated,
+                       never read and never rendered anywhere. *@
+                    @foreach (var (member, position) in State.Team.Select((m, i) => (m, i + 1)))
                     {
-                        var idx = i;
-                        <tr>
-                            <td class="row-number">@(idx + 1)</td>
+                        <tr @key="member.Id">
+                            @* Display only. It is a position, not an identity, and it is
+                               deliberately not used for binding or removal. *@
+                            <td class="row-number">@position</td>
                             <td>
-                                <input type="text" @bind="State.Team[idx].Name" placeholder="Imię..." />
+                                <input type="text" @bind="member.Name" placeholder="Imię..." />
                             </td>
                             <td>
-                                <select @bind="State.Team[idx].Role">
+                                <select @bind="member.Role">
                                     <option value="Developer">Developer</option>
                                     <option value="QA">QA / Tester</option>
                                     <option value="DevOps">DevOps</option>
@@ -80,11 +100,18 @@
                                 </select>
                             </td>
                             <td>
-                                <input type="number" @bind="State.Team[idx].Weight"
+                                <input type="number" @bind="member.Weight"
                                        min="0.1" max="2.0" step="0.05" />
                             </td>
                             <td>
-                                <button class="btn-remove" @onclick="() => RemoveMember(idx)"
+                                @* Disabled rather than silently inert at one member.
+                                   A team of zero makes CalculateTeamWeight return its
+                                   sentinel 1.0, which is a different model rather than an
+                                   empty one — so the floor is real, and the reader should
+                                   be able to see it rather than click and have nothing
+                                   happen. *@
+                                <button class="btn-remove" @onclick="() => State.RemoveMember(member)"
+                                        disabled="@(!State.CanRemoveMember)"
                                         title="Usuń członka zespołu">✕</button>
                             </td>
                         </tr>
@@ -125,11 +152,6 @@
     // construct the state without instantiating a page.
 
     private IReadOnlyList<string> Problems => State.Problems;
-
-    private void RemoveMember(int index)
-    {
-        State.RemoveMember(State.Team[index]);
-    }
 
     private void GenerateChart()
     {

--- a/tests/SupercompensationApp.Tests/AppStateServiceTests.cs
+++ b/tests/SupercompensationApp.Tests/AppStateServiceTests.cs
@@ -163,6 +163,58 @@ public class AppStateServiceTests
             "and it should be the one that was passed in, identified by Id.");
     }
 
+    [Fact]
+    public void MemberIdsStayUniqueAcrossAddRemoveAndResetCycles()
+    {
+        // TeamMember.Id is now the @key for the team table rows (#13), so a duplicate id
+        // would make Blazor's diff match two different rows to one rendered element —
+        // reintroducing the very defect @key was added to fix, and in a form that is
+        // harder to see because the markup looks correct.
+        var state = NewState();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        void Record()
+        {
+            foreach (var member in state.Team)
+            {
+                Assert.True(
+                    !string.IsNullOrWhiteSpace(member.Id),
+                    "Every member needs an id: it is what keys the table row.");
+            }
+
+            var ids = state.Team.Select(m => m.Id).ToList();
+            Assert.True(
+                ids.Distinct(StringComparer.Ordinal).Count() == ids.Count,
+                $"Ids must be unique within the team, got: {string.Join(", ", ids)}");
+
+            foreach (var id in ids)
+            {
+                seen.Add(id);
+            }
+        }
+
+        Record();
+
+        for (var cycle = 0; cycle < 3; cycle++)
+        {
+            state.AddMember();
+            state.AddMember();
+            Record();
+
+            state.RemoveMember(state.Team[1]);
+            Record();
+
+            state.ResetTeam();
+            Record();
+        }
+
+        Assert.True(
+            seen.Count > state.Team.Count,
+            "Sanity check on the test: across three add/remove/reset cycles it should " +
+            "have observed more distinct ids than a single team holds, or it is not " +
+            "exercising anything.");
+    }
+
     // ── Change notification ──────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
Closes #13

## What changed

- `Pages/Index.razor` — index loop → `@foreach` with `@key="member.Id"`; every binding
  goes to the member rather than through `Team[index]`; the remove button is `disabled`
  at one member.
- `tests/…/AppStateServiceTests.cs` — id uniqueness across add/remove/reset cycles.

## Why

Without `@key`, Blazor's diff matches rendered elements to the previous render **by
position**. Remove the member at index 2 of seven, every row below shifts up one, and the
renderer keeps the existing `<input>` elements where they are while rewriting their values
against the *new* occupant of each position.

`@bind` on a text input commits on **blur**, so the concrete loss was: type a name into
row 5, click ✕ on row 2 without leaving the field first, and the pending value is
committed against whichever member has moved into position 5. Element state Blazor does
not own — caret position, native validation state, an open `<select>` — follows the DOM
node rather than the model for the same reason.

`TeamMember.Id` already existed for precisely this. It was generated on every member,
**read nowhere** in the codebase and rendered nowhere. This is what it is for.

## The `#` column

`@foreach` has no index, so the column takes a display position from
`Select((m, i) => i + 1)`. It is deliberately *not* used for binding or removal — it is a
position, not an identity, and reintroducing index-based binding to keep a cosmetic
number would undo the change. There is a comment saying so at the site.

## The remove button

Now `disabled` at one member rather than silently ignoring the click. The floor is real —
a team of zero makes `CalculateTeamWeight` return its sentinel `1.0`, which is a
*different* model rather than an empty one — and `State.CanRemoveMember` (added in #12)
exposes it so the UI can show it.

## Verification, and what I could not run

**Done:**
- No binding goes through `Team[index]` any more (`grep 'Team\['` finds only a comment).
- Each `<tr>` carries `@key` bound to `TeamMember.Id`.
- A test asserts ids stay unique across three add/remove/reset cycles, with a
  sanity-check that the test itself observes more distinct ids than one team holds — a
  uniqueness test over a set that never changes proves nothing.

That last test matters more after this change than before it: a duplicate id would make
the diff match two rows to one element, reintroducing the defect `@key` fixes, in a form
that is *harder* to spot because the markup would look correct.

**Not done, and stated rather than glossed:** the issue's headline acceptance criterion is
to reproduce the defect by typing into a row, removing another without blurring, and
checking that no name changed. **I could not execute that.** It requires rendering a
Blazor component, there is no .NET SDK in this environment, and asserting it in CI would
need bUnit, which this repository does not have.

So this rests on the framework's documented diffing behaviour and on the code reading,
not on a run. The same honesty applied to #10's `@bind:culture` question.

🔀 **DECISION: bUnit not added here.** It is the right tool for exactly this criterion and
would make a whole class of markup defects testable — but adding a test framework is a
testing-infrastructure decision that deserves its own issue and its own review, not
smuggling into a `@key` fix. Recommending it as a follow-up rather than doing it silently.

## Note for whoever picks this up

#10 left a question on this issue: whether `@bind` on `<input type="number">` parses with
the current culture. My reading is that Blazor already forces invariant there
(`isInvariantCulture: true` on its `number` bind attribute), and this PR does not change
it. If a team weight of `0.95` fails to round-trip under a Polish browser locale, that is
where to look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_