### PR TITLE
Persist the configuration and team across reloads

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -1,4 +1,6 @@
 @inherits LayoutComponentBase
+@inject AppStateService State
+
 
 <div class="app-container">
     <header class="app-header">
@@ -27,3 +29,12 @@
         <p>Feedback i hiperkompensacja — zarządzanie IT w 2026 · Konrad</p>
     </footer>
 </div>
+
+@code {
+    // MainLayout wraps every page, so this runs once at startup regardless of which
+    // route the user landed on — including a deep link straight to /chart or /data.
+    protected override async Task OnInitializedAsync()
+    {
+        await State.LoadAsync();
+    }
+}

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -5,37 +5,45 @@
 <PageTitle>Konfiguracja — Supercompensation</PageTitle>
 
 <div class="config-page">
+    @if (State.RestoreFailed)
+    {
+        <p class="stale-notice">
+            ⚠️ Nie udało się odczytać zapisanej konfiguracji — mogła zostać zapisana przez
+            starszą wersję aplikacji. Wczytano ustawienia domyślne.
+        </p>
+    }
+
     <section class="config-section">
         <h2>🏃 Parametry Sprintu</h2>
         <div class="param-grid">
             <div class="param-card">
                 <label>Czas trwania sprintu (dni)</label>
-                <input type="number" @bind="State.Config.SprintDuration" min="5" max="30" />
+                <input type="number" @bind="State.Config.SprintDuration" @bind:after="State.OnEditedAsync" min="5" max="30" />
                 <span class="param-hint">Domyślnie: 10</span>
             </div>
             <div class="param-card">
                 <label>Liczba sprintów</label>
-                <input type="number" @bind="State.Config.NumberOfSprints" min="1" max="20" />
+                <input type="number" @bind="State.Config.NumberOfSprints" @bind:after="State.OnEditedAsync" min="1" max="20" />
                 <span class="param-hint">Domyślnie: 3</span>
             </div>
             <div class="param-card">
                 <label>Przyrost baseline</label>
-                <input type="number" @bind="State.Config.BaselineIncrement" min="0" max="50" step="0.5" />
+                <input type="number" @bind="State.Config.BaselineIncrement" @bind:after="State.OnEditedAsync" min="0" max="50" step="0.5" />
                 <span class="param-hint">Wzrost po każdym sprincie</span>
             </div>
             <div class="param-card">
                 <label>Początkowy baseline</label>
-                <input type="number" @bind="State.Config.InitialBaseline" min="50" max="200" step="5" />
+                <input type="number" @bind="State.Config.InitialBaseline" @bind:after="State.OnEditedAsync" min="50" max="200" step="5" />
                 <span class="param-hint">Startowa wydajność bazowa</span>
             </div>
             <div class="param-card">
                 <label>Głębokość zmęczenia</label>
-                <input type="number" @bind="State.Config.FatigueDepth" min="5" max="50" step="1" />
+                <input type="number" @bind="State.Config.FatigueDepth" @bind:after="State.OnEditedAsync" min="5" max="50" step="1" />
                 <span class="param-hint">Jak głęboko spada krzywa</span>
             </div>
             <div class="param-card">
                 <label>Szczyt superkompensacji</label>
-                <input type="number" @bind="State.Config.SupercompensationPeak" min="5" max="40" step="1" />
+                <input type="number" @bind="State.Config.SupercompensationPeak" @bind:after="State.OnEditedAsync" min="5" max="40" step="1" />
                 <span class="param-hint">Jak wysoko ponad baseline</span>
             </div>
         </div>
@@ -85,10 +93,10 @@
                                deliberately not used for binding or removal. *@
                             <td class="row-number">@position</td>
                             <td>
-                                <input type="text" @bind="member.Name" placeholder="Imię..." />
+                                <input type="text" @bind="member.Name" @bind:after="State.OnEditedAsync" placeholder="Imię..." />
                             </td>
                             <td>
-                                <select @bind="member.Role">
+                                <select @bind="member.Role" @bind:after="State.OnEditedAsync">
                                     <option value="Developer">Developer</option>
                                     <option value="QA">QA / Tester</option>
                                     <option value="DevOps">DevOps</option>
@@ -100,7 +108,7 @@
                                 </select>
                             </td>
                             <td>
-                                <input type="number" @bind="member.Weight"
+                                <input type="number" @bind="member.Weight" @bind:after="State.OnEditedAsync"
                                        min="0.1" max="2.0" step="0.05" />
                             </td>
                             <td>
@@ -110,7 +118,7 @@
                                    empty one — so the floor is real, and the reader should
                                    be able to see it rather than click and have nothing
                                    happen. *@
-                                <button class="btn-remove" @onclick="() => State.RemoveMember(member)"
+                                <button class="btn-remove" @onclick="() => State.RemoveMemberAsync(member)"
                                         disabled="@(!State.CanRemoveMember)"
                                         title="Usuń członka zespołu">✕</button>
                             </td>
@@ -121,10 +129,10 @@
         </div>
 
         <div class="team-actions">
-            <button class="btn-add" @onclick="State.AddMember">
+            <button class="btn-add" @onclick="State.AddMemberAsync">
                 ➕ Dodaj członka zespołu
             </button>
-            <button class="btn-reset" @onclick="State.ResetTeam">
+            <button class="btn-reset" @onclick="State.ResetTeamAsync">
                 🔄 Przywróć domyślny zespół
             </button>
         </div>

--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,10 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddSingleton<SupercompensationService>();
 
+// Browser localStorage, behind an interface so the serialisation round-trip can be
+// tested without a browser.
+builder.Services.AddSingleton<IStateStore, LocalStorageStateStore>();
+
 // The application's state, replacing four `public static` properties that used to live
 // on Pages/Index.razor. Singleton rather than scoped: Blazor WebAssembly is single-user,
 // and scoped would behave identically here while saying something untrue about lifetime.

--- a/Services/AppStateService.cs
+++ b/Services/AppStateService.cs
@@ -31,6 +31,15 @@ using SupercompensationApp.Models;
 public class AppStateService
 {
     private readonly SupercompensationService _service;
+    private readonly IStateStore _store;
+
+    /// <summary>
+    /// Increments on every edit. A debounced save captures the value, waits, and only
+    /// writes if nothing has superseded it. Blazor WebAssembly is single-threaded, so a
+    /// plain counter is correct here and is a great deal easier to read than a
+    /// CancellationTokenSource that has to be cancelled and disposed in the right order.
+    /// </summary>
+    private int _editSequence;
 
     /// <summary>
     /// The signature of the configuration and team that produced the current results.
@@ -38,10 +47,24 @@ public class AppStateService
     /// </summary>
     private string? _resultsSignature;
 
-    public AppStateService(SupercompensationService service)
+    public AppStateService(SupercompensationService service, IStateStore store)
     {
         _service = service ?? throw new ArgumentNullException(nameof(service));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
     }
+
+    /// <summary>
+    /// How long an edit waits before being written. Settable so a test does not have to
+    /// sleep for real time to exercise the debounce.
+    /// </summary>
+    public TimeSpan SaveDelay { get; set; } = TimeSpan.FromMilliseconds(400);
+
+    /// <summary>
+    /// True when a stored payload was found and could not be used, so the application is
+    /// showing defaults instead. Surfaced in the UI: an empty team with no explanation is
+    /// worse than a lost one with a sentence.
+    /// </summary>
+    public bool RestoreFailed { get; private set; }
 
     /// <summary>
     /// Raised when the state changes in a way another page should notice. A page
@@ -134,6 +157,109 @@ public class AppStateService
     {
         Team = TeamMember.GetDefaultTeam();
         NotifyChanged();
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Restores the configuration and team from browser storage.
+    ///
+    /// Called once from MainLayout, which wraps every page, so it runs before anything is
+    /// shown regardless of which route the user landed on.
+    /// </summary>
+    public async Task LoadAsync()
+    {
+        var json = await _store.ReadAsync(StateSerializer.StorageKey);
+
+        if (json is null)
+        {
+            // Nothing stored. A first visit, or storage is unavailable. Neither is a
+            // failure and neither should say anything to the user.
+            RestoreFailed = false;
+            return;
+        }
+
+        if (StateSerializer.TryDeserialize(json, out var config, out var team))
+        {
+            Config = config;
+            Team = team;
+            RestoreFailed = false;
+        }
+        else
+        {
+            // Corrupt, hand-edited, or written by an older schema. Keep the defaults
+            // already in place and say so rather than failing silently.
+            RestoreFailed = true;
+        }
+
+        NotifyChanged();
+    }
+
+    /// <summary>
+    /// Writes the current configuration and team immediately.
+    /// </summary>
+    public async Task SaveAsync()
+    {
+        await _store.WriteAsync(
+            StateSerializer.StorageKey,
+            StateSerializer.Serialize(Config, Team));
+    }
+
+    /// <summary>
+    /// Call from a binding's @bind:after, or after a team change. Notifies subscribers
+    /// and schedules a debounced write.
+    ///
+    /// Debounced rather than saved per keystroke because @bind:after fires on every
+    /// committed edit across six numeric fields and a row per team member; and there is
+    /// deliberately no Save button, because a persistence problem should not be solved by
+    /// adding an affordance the UI does not otherwise have.
+    /// </summary>
+    public async Task OnEditedAsync()
+    {
+        NotifyChanged();
+
+        // Interlocked/Volatile rather than a bare ++ and ==. Blazor WebAssembly is
+        // single-threaded so this is not needed in production, but a Task.Delay
+        // continuation resumes on a pool thread under a test runner, and a persistence
+        // test that fails one run in fifty is worse than a slightly noisier line.
+        var mine = Interlocked.Increment(ref _editSequence);
+
+        if (SaveDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(SaveDelay);
+        }
+
+        if (mine != Volatile.Read(ref _editSequence))
+        {
+            // A later edit arrived while this one was waiting; that one will write.
+            return;
+        }
+
+        await SaveAsync();
+    }
+
+    public async Task AddMemberAsync()
+    {
+        AddMember();
+        await SaveAsync();
+    }
+
+    public async Task RemoveMemberAsync(TeamMember member)
+    {
+        RemoveMember(member);
+        await SaveAsync();
+    }
+
+    /// <summary>
+    /// Restores the default team AND clears the stored copy. Without the second half the
+    /// next reload would undo the reset, which is the kind of thing that reads as the
+    /// application ignoring you.
+    /// </summary>
+    public async Task ResetTeamAsync()
+    {
+        ResetTeam();
+        RestoreFailed = false;
+        await _store.RemoveAsync(StateSerializer.StorageKey);
     }
 
     /// <summary>

--- a/Services/IStateStore.cs
+++ b/Services/IStateStore.cs
@@ -1,0 +1,24 @@
+namespace SupercompensationApp.Services;
+
+/// <summary>
+/// A key/value store for the application's persisted state.
+///
+/// It is an interface for one reason that matters: browser storage cannot be reached
+/// from a unit test, and the round-trip this abstraction guards — a configuration and a
+/// team surviving serialisation unchanged — is exactly what needs testing. The JS-backed
+/// implementation is a thin adapter; the logic sits in StateSerializer, which is static
+/// and needs no browser at all.
+///
+/// Every method is allowed to fail silently. localStorage is not merely empty in a
+/// private window or with site data blocked — ACCESSING it throws — so a store that
+/// propagated failures would turn "storage is disabled" into an unhandled exception on
+/// startup.
+/// </summary>
+public interface IStateStore
+{
+    ValueTask<string?> ReadAsync(string key);
+
+    ValueTask WriteAsync(string key, string value);
+
+    ValueTask RemoveAsync(string key);
+}

--- a/Services/LocalStorageStateStore.cs
+++ b/Services/LocalStorageStateStore.cs
@@ -1,0 +1,58 @@
+namespace SupercompensationApp.Services;
+
+using Microsoft.JSInterop;
+
+/// <summary>
+/// Browser localStorage, through the guarded helpers in wwwroot/js/storage-interop.js.
+///
+/// The guarding lives in JavaScript rather than here because that is where the throw
+/// happens: reading window.localStorage raises a SecurityError outright in a private
+/// window or when a browser is set to block site data, before any key is named. Catching
+/// on the .NET side would work for the interop call but leaves the failure mode
+/// documented in the wrong file.
+/// </summary>
+public class LocalStorageStateStore : IStateStore
+{
+    private readonly IJSRuntime _js;
+
+    public LocalStorageStateStore(IJSRuntime js)
+    {
+        _js = js ?? throw new ArgumentNullException(nameof(js));
+    }
+
+    public async ValueTask<string?> ReadAsync(string key)
+    {
+        try
+        {
+            return await _js.InvokeAsync<string?>("supercompStorage.read", key);
+        }
+        catch (JSException)
+        {
+            return null;
+        }
+    }
+
+    public async ValueTask WriteAsync(string key, string value)
+    {
+        try
+        {
+            await _js.InvokeVoidAsync("supercompStorage.write", key, value);
+        }
+        catch (JSException)
+        {
+            // Storage is unavailable or full. The application works without it; losing
+            // the write is strictly better than losing the session.
+        }
+    }
+
+    public async ValueTask RemoveAsync(string key)
+    {
+        try
+        {
+            await _js.InvokeVoidAsync("supercompStorage.remove", key);
+        }
+        catch (JSException)
+        {
+        }
+    }
+}

--- a/Services/StateSerializer.cs
+++ b/Services/StateSerializer.cs
@@ -1,0 +1,130 @@
+namespace SupercompensationApp.Services;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using SupercompensationApp.Models;
+
+/// <summary>
+/// The persisted payload. Versioned on purpose — see StateSerializer.
+/// </summary>
+public sealed class PersistedState
+{
+    public int SchemaVersion { get; set; }
+
+    public SprintConfiguration? Config { get; set; }
+
+    public List<TeamMember>? Team { get; set; }
+}
+
+/// <summary>
+/// Turns the configuration and team into a string and back.
+///
+/// Static and browser-free on purpose: this is where the interesting behaviour is, so it
+/// is the part that has to be testable. IStateStore is the thin adapter around it.
+///
+/// What is NOT persisted: ChartDataSet and the table rows. They are derived, they are the
+/// largest objects in the application (600 rows at the UI's maximums), and a stored copy
+/// is a second source of truth that can disagree with the configuration that produced it
+/// — which is the defect #12 had just finished making visible. They are regenerated.
+/// </summary>
+public static class StateSerializer
+{
+    /// <summary>
+    /// Bumped whenever the stored shape changes incompatibly. A payload written by a
+    /// different version is discarded rather than half-read: the alternative is a
+    /// TeamMember with a field that no longer exists, deserialised into a partly-empty
+    /// object, which fails somewhere far away from the cause.
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    public const string StorageKey = "supercompensation.state.v1";
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        // System.Text.Json writes numbers per the JSON grammar rather than per the
+        // current culture, so a decimal point is guaranteed here in a way it was NOT
+        // guaranteed in the CSV export before #10. The round-trip is asserted under
+        // pl-PL and en-US anyway: the guarantee is worth having a test behind rather
+        // than a comment.
+        WriteIndented = false,
+    };
+
+    public static string Serialize(SprintConfiguration config, IReadOnlyList<TeamMember> team)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(team);
+
+        return JsonSerializer.Serialize(
+            new PersistedState
+            {
+                SchemaVersion = CurrentSchemaVersion,
+                Config = config,
+                Team = [.. team],
+            },
+            Options);
+    }
+
+    /// <summary>
+    /// Reads a payload back, or reports that it could not.
+    ///
+    /// Fails soft in every case, and the caller shows the defaults instead. A stored blob
+    /// written by an older shape of TeamMember must not throw on load: the user would get
+    /// a blank application with no explanation, which is worse than losing the saved team.
+    /// </summary>
+    public static bool TryDeserialize(
+        string? json,
+        out SprintConfiguration config,
+        out List<TeamMember> team)
+    {
+        config = new SprintConfiguration();
+        team = TeamMember.GetDefaultTeam();
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return false;
+        }
+
+        PersistedState? stored;
+        try
+        {
+            stored = JsonSerializer.Deserialize<PersistedState>(json, Options);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (stored is null || stored.SchemaVersion != CurrentSchemaVersion)
+        {
+            return false;
+        }
+
+        if (stored.Config is null || stored.Team is null || stored.Team.Count == 0)
+        {
+            return false;
+        }
+
+        // A payload can be well-formed and still unusable. Anything written before #11
+        // added validation — or edited by hand in devtools — could carry a SprintDuration
+        // of 0, and loading it would put the application straight back into the NaN state
+        // that issue removed.
+        if (stored.Config.Validate().Count > 0)
+        {
+            return false;
+        }
+
+        // An id is what keys the team table rows (#13). A stored payload with duplicates
+        // would make Blazor's diff match two rows to one element.
+        var ids = stored.Team.Select(m => m.Id).ToList();
+        if (ids.Exists(string.IsNullOrWhiteSpace) ||
+            ids.Distinct(StringComparer.Ordinal).Count() != ids.Count)
+        {
+            return false;
+        }
+
+        config = stored.Config;
+        team = stored.Team;
+        return true;
+    }
+}

--- a/tests/SupercompensationApp.Tests/AppStateServiceTests.cs
+++ b/tests/SupercompensationApp.Tests/AppStateServiceTests.cs
@@ -13,7 +13,8 @@ using Xunit;
 /// </summary>
 public class AppStateServiceTests
 {
-    private static AppStateService NewState() => new(new SupercompensationService());
+    private static AppStateService NewState() =>
+        new(new SupercompensationService(), new InMemoryStateStore());
 
     [Fact]
     public void ItStartsWithTheDefaultTeamAndNoResults()

--- a/tests/SupercompensationApp.Tests/InMemoryStateStore.cs
+++ b/tests/SupercompensationApp.Tests/InMemoryStateStore.cs
@@ -1,0 +1,48 @@
+namespace SupercompensationApp.Tests;
+
+using SupercompensationApp.Services;
+
+/// <summary>
+/// A test double for IStateStore. Browser storage cannot be reached from a unit test,
+/// which is the whole reason IStateStore is an interface.
+///
+/// It can also be told to behave like storage that is unavailable — which is not a
+/// hypothetical: reading window.localStorage throws outright in a private window and in
+/// any browser set to block site data.
+/// </summary>
+public class InMemoryStateStore : IStateStore
+{
+    private readonly Dictionary<string, string> _items = new(StringComparer.Ordinal);
+
+    /// <summary>Simulates storage that is present but refuses every operation.</summary>
+    public bool Unavailable { get; set; }
+
+    public int Writes { get; private set; }
+
+    public int Removes { get; private set; }
+
+    public string? Peek(string key) => _items.TryGetValue(key, out var v) ? v : null;
+
+    public void Seed(string key, string value) => _items[key] = value;
+
+    public ValueTask<string?> ReadAsync(string key) =>
+        ValueTask.FromResult(Unavailable ? null : Peek(key));
+
+    public ValueTask WriteAsync(string key, string value)
+    {
+        Writes++;
+        if (!Unavailable)
+        {
+            _items[key] = value;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask RemoveAsync(string key)
+    {
+        Removes++;
+        _items.Remove(key);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/SupercompensationApp.Tests/StatePersistenceTests.cs
+++ b/tests/SupercompensationApp.Tests/StatePersistenceTests.cs
@@ -1,0 +1,241 @@
+namespace SupercompensationApp.Tests;
+
+using System.Globalization;
+using SupercompensationApp.Models;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// Everything the user types was lost on refresh: the state lives in memory, and a Blazor
+/// WebAssembly reload reconstructs the application, so GetDefaultTeam() runs again and the
+/// seven default members come back.
+///
+/// That is a real cost rather than a nicety. The configuration screen is "edycja zespołu
+/// (jak Excel)" — seven rows of name, role and weight — and there is no server and no
+/// account, so if the browser does not remember, nothing does.
+/// </summary>
+public class StatePersistenceTests
+{
+    private static (AppStateService State, InMemoryStateStore Store) NewState()
+    {
+        var store = new InMemoryStateStore();
+        var state = new AppStateService(new SupercompensationService(), store)
+        {
+            // Tests should not sleep for real time to exercise a debounce.
+            SaveDelay = TimeSpan.Zero,
+        };
+        return (state, store);
+    }
+
+    // ── The round trip ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConfigurationAndTeamSurviveAReload()
+    {
+        var (state, store) = NewState();
+        state.Config.SprintDuration = 14;
+        state.Config.FatigueDepth = 31.0;
+        state.Team[0].Name = "Ada";
+        state.Team[0].Weight = 1.25;
+        await state.SaveAsync();
+
+        // A reload is a brand new service against the same storage.
+        var reloaded = new AppStateService(new SupercompensationService(), store);
+        await reloaded.LoadAsync();
+
+        Assert.True(reloaded.Config.SprintDuration == 14, $"Got {reloaded.Config.SprintDuration}.");
+        Assert.True(reloaded.Config.FatigueDepth == 31.0, $"Got {reloaded.Config.FatigueDepth}.");
+        Assert.True(reloaded.Team[0].Name == "Ada", $"Got {reloaded.Team[0].Name}.");
+        Assert.True(reloaded.Team[0].Weight == 1.25, $"Got {reloaded.Team[0].Weight}.");
+        Assert.True(!reloaded.RestoreFailed, "A clean payload must not report a failure.");
+    }
+
+    [Fact]
+    public void TheSerialisedFormDoesNotDependOnTheMachinesCulture()
+    {
+        // The same reasoning as #10, one layer down. System.Text.Json writes numbers per
+        // the JSON grammar rather than per the current culture, so this should hold — and
+        // that guarantee is worth a test rather than a comment, because the CSV export
+        // carried the same assumption and it was false there.
+        static string Under(string culture, Func<string> action)
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+                return action();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        var config = new SprintConfiguration { BaselineIncrement = 12.5, FatigueDepth = 33.75 };
+        var team = TeamMember.GetDefaultTeam();
+
+        var polish = Under("pl-PL", () => StateSerializer.Serialize(config, team));
+        var american = Under("en-US", () => StateSerializer.Serialize(config, team));
+
+        Assert.True(
+            polish == american,
+            $"The stored payload must be byte-identical across cultures.\n" +
+            $"pl-PL: {polish}\nen-US: {american}");
+
+        Assert.True(
+            polish.Contains("12.5", StringComparison.Ordinal),
+            $"and decimals must use a point: {polish}");
+    }
+
+    // ── Failing soft ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ACorruptPayloadLoadsDefaultsAndSaysSo()
+    {
+        var (state, store) = NewState();
+        store.Seed(StateSerializer.StorageKey, "{ this is not json");
+
+        await state.LoadAsync();
+
+        Assert.True(state.Team.Count == TeamMember.GetDefaultTeam().Count, "Defaults restored.");
+        Assert.True(
+            state.RestoreFailed,
+            "A corrupt payload must be visible to the user. A blank team with no " +
+            "explanation is worse than a lost one with a sentence.");
+    }
+
+    [Fact]
+    public void APayloadFromAnotherSchemaVersionIsDiscarded()
+    {
+        var json = $$"""
+            {"SchemaVersion":{{StateSerializer.CurrentSchemaVersion + 1}},"Config":{"SprintDuration":9},"Team":[]}
+            """;
+
+        var ok = StateSerializer.TryDeserialize(json, out var config, out var team);
+
+        Assert.True(!ok, "A different schema version must not be read.");
+        Assert.True(config.SprintDuration == 10, "Defaults are returned instead.");
+        Assert.True(team.Count > 0, "including the default team.");
+    }
+
+    [Fact]
+    public void AStoredConfigurationOutsideTheAllowedRangeIsRejected()
+    {
+        // Anything written before #11 added validation, or edited by hand in devtools,
+        // could carry SprintDuration = 0 — and loading it would put the application
+        // straight back into the NaN state that issue removed.
+        var config = new SprintConfiguration();
+        var json = StateSerializer.Serialize(config, TeamMember.GetDefaultTeam())
+            .Replace("\"SprintDuration\":10", "\"SprintDuration\":0", StringComparison.Ordinal);
+
+        var ok = StateSerializer.TryDeserialize(json, out var loaded, out _);
+
+        Assert.True(!ok, "A payload that fails validation must not be loaded.");
+        Assert.True(loaded.Validate().Count == 0, "and the fallback must itself be valid.");
+    }
+
+    [Fact]
+    public void APayloadWithDuplicateMemberIdsIsRejected()
+    {
+        // Id is what keys the team table rows (#13); duplicates would make Blazor's diff
+        // match two rows to one element.
+        var team = TeamMember.GetDefaultTeam();
+        team[1].Id = team[0].Id;
+        var json = StateSerializer.Serialize(new SprintConfiguration(), team);
+
+        var ok = StateSerializer.TryDeserialize(json, out _, out var loaded);
+
+        Assert.True(!ok, "Duplicate ids must be rejected.");
+        var ids = loaded.Select(m => m.Id).ToList();
+        Assert.True(
+            ids.Distinct(StringComparer.Ordinal).Count() == ids.Count,
+            "and the fallback team must have unique ids.");
+    }
+
+    [Fact]
+    public async Task AnEmptyStoreIsNotAFailure()
+    {
+        var (state, _) = NewState();
+
+        await state.LoadAsync();
+
+        Assert.True(
+            !state.RestoreFailed,
+            "A first visit, or storage being unavailable, is not a failure and must not " +
+            "say anything to the user.");
+    }
+
+    [Fact]
+    public async Task UnavailableStorageDegradesToInMemoryStateRatherThanThrowing()
+    {
+        var (state, store) = NewState();
+        store.Unavailable = true;
+
+        await state.LoadAsync();
+        state.Config.SprintDuration = 12;
+        await state.SaveAsync();
+        await state.AddMemberAsync();
+
+        Assert.True(state.Config.SprintDuration == 12, "The session still works in memory.");
+        Assert.True(!state.RestoreFailed, "Storage being off is not a corrupt payload.");
+    }
+
+    // ── Derived data is not persisted ────────────────────────────────────────
+
+    [Fact]
+    public async Task GeneratedResultsAreNotWrittenToStorage()
+    {
+        var (state, store) = NewState();
+        state.Generate();
+        await state.SaveAsync();
+
+        var payload = store.Peek(StateSerializer.StorageKey);
+
+        Assert.True(payload is not null, "Something should have been written.");
+        Assert.True(
+            !payload!.Contains("Summaries", StringComparison.Ordinal) &&
+            !payload.Contains("Performance", StringComparison.Ordinal),
+            $"Derived data must not be persisted: it is the largest object in the app, " +
+            $"and a stored copy is a second source of truth that can disagree with the " +
+            $"configuration that produced it. Payload: {payload}");
+    }
+
+    // ── Reset clears the stored copy ─────────────────────────────────────────
+
+    [Fact]
+    public async Task ResettingTheTeamClearsWhatWasStored()
+    {
+        var (state, store) = NewState();
+        state.Team[0].Name = "Ada";
+        await state.SaveAsync();
+        Assert.True(store.Peek(StateSerializer.StorageKey) is not null, "Precondition.");
+
+        await state.ResetTeamAsync();
+
+        Assert.True(
+            store.Peek(StateSerializer.StorageKey) is null,
+            "Without clearing the stored copy the next reload would undo the reset, " +
+            "which reads as the application ignoring you.");
+    }
+
+    // ── The debounce ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RapidEditsCollapseIntoASingleWrite()
+    {
+        var (state, store) = NewState();
+        state.SaveDelay = TimeSpan.FromMilliseconds(60);
+
+        // Three edits started in quick succession: the first two should be superseded.
+        var first = state.OnEditedAsync();
+        var second = state.OnEditedAsync();
+        var third = state.OnEditedAsync();
+        await Task.WhenAll(first, second, third);
+
+        Assert.True(
+            store.Writes == 1,
+            $"Three rapid edits should collapse into one write, got {store.Writes}. " +
+            $"@bind:after fires on every committed edit across six numeric fields plus a " +
+            $"row per team member.");
+    }
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -50,5 +50,6 @@
 
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="js/chart-interop.js"></script>
+    <script src="js/storage-interop.js"></script>
 </body>
 </html>

--- a/wwwroot/js/storage-interop.js
+++ b/wwwroot/js/storage-interop.js
@@ -1,0 +1,33 @@
+// localStorage access, guarded.
+//
+// Every method here is wrapped, and not defensively-for-the-sake-of-it: reading
+// `window.localStorage` THROWS a SecurityError in a private window and in any browser
+// configured to block site data — before a key is even named. An unguarded getItem is
+// therefore an unhandled exception on startup for a class of user who has done nothing
+// wrong, and the application works perfectly well without persistence.
+//
+// setItem additionally throws QuotaExceededError when the origin's storage is full.
+window.supercompStorage = {
+    read: function (key) {
+        try {
+            return window.localStorage.getItem(key);
+        } catch (e) {
+            return null;
+        }
+    },
+
+    write: function (key, value) {
+        try {
+            window.localStorage.setItem(key, value);
+        } catch (e) {
+            // Full, or unavailable. Nothing to do and nothing worth interrupting for.
+        }
+    },
+
+    remove: function (key) {
+        try {
+            window.localStorage.removeItem(key);
+        } catch (e) {
+        }
+    }
+};


### PR DESCRIPTION
Closes #14

## What changed

- `Services/StateSerializer.cs` — versioned payload, serialize/try-deserialize. Static,
  browser-free.
- `Services/IStateStore.cs` + `LocalStorageStateStore.cs` — the thin adapter.
- `wwwroot/js/storage-interop.js` — guarded `localStorage` access.
- `Services/AppStateService.cs` — `LoadAsync`, `SaveAsync`, debounced `OnEditedAsync`,
  `RestoreFailed`.
- `Layout/MainLayout.razor` — restores once at startup.
- `Pages/Index.razor` — `@bind:after` on all nine fields; async team mutators; a notice.
- `tests/…` — `InMemoryStateStore` + eleven persistence tests.

## Why

Everything the user typed was lost on refresh. A Blazor WebAssembly reload reconstructs
the application, so `GetDefaultTeam()` runs again and the seven defaults come back. The
configuration screen is described in the README as *"edycja zespołu (jak Excel)"* — seven
rows of name, role and weight — and with no server and no account, **if the browser does
not remember, nothing does.**

## The split that makes this testable

The interesting behaviour is serialisation and the fail-soft paths; the browser is
incidental. So `StateSerializer` is static and needs no browser, and `IStateStore` is a
thin adapter with an in-memory double for tests. Without that split the fail-soft cases
would have been reasoned about rather than tested.

## Guarded in JavaScript, not C#

Reading `window.localStorage` **throws a SecurityError outright** in a private window and
in any browser set to block site data — before a key is even named. So an unguarded
`getItem` is an unhandled exception on startup for a user who has done nothing wrong, and
the app works fine without persistence. The guard lives in JS because that is where the
throw happens; catching on the .NET side would work but would document the failure mode
in the wrong file.

## Every unusable payload falls back, visibly

| Case | Result |
|---|---|
| Corrupt JSON | defaults + notice |
| Different `SchemaVersion` | defaults + notice |
| Missing config or empty team | defaults + notice |
| **Config that fails validation** | defaults + notice |
| **Duplicate member ids** | defaults + notice |
| Nothing stored / storage unavailable | defaults, **no** notice |

The last row matters: a first visit is not a failure and must not say anything.

The two bolded rows are the ones a generic implementation would miss. A payload written
before #11 added validation — or edited by hand in devtools — could carry
`SprintDuration = 0`, and loading it would restore the exact NaN state that issue removed.
And `Id` is what keys the table rows since #13, so duplicates would make Blazor's diff
match two rows to one element.

## Derived data is not persisted, and that is asserted

`ChartDataSet` and the 600-row table are regenerated. A stored copy is a second source of
truth that can disagree with the configuration that produced it — the defect #12 had just
finished making visible. A test checks the payload contains neither `Summaries` nor
`Performance`, rather than trusting the intent.

## The debounce

An edit sequence, not a `CancellationTokenSource`: WASM is single-threaded so a counter is
correct, and it is far easier to read than a CTS that must be cancelled and disposed in
the right order.

`Interlocked`/`Volatile` are used anyway — not for production, but because a `Task.Delay`
continuation resumes on a pool thread under the test runner, and a persistence test that
fails one run in fifty is worse than a slightly noisier line. Tested: three rapid edits
collapse to **one** write.

`@bind:after` fires on every committed edit across six numeric fields plus a row per team
member, which is why the debounce exists. There is deliberately no Save button — a
persistence problem should not be solved by adding an affordance the UI does not otherwise
have.

## Reset clears the stored copy

`ResetTeamAsync` removes the key as well as restoring the team. Without that the next
reload would undo the reset, which reads as the application ignoring you.

## Culture

The round trip is asserted byte-identical under `pl-PL` and `en-US`. `System.Text.Json`
writes numbers per the JSON grammar rather than per the culture, so this *should* hold —
but the CSV export carried exactly the same assumption before #10 and it was **false**
there. That is worth a test rather than a comment.

## Not executed

The browser-restart criterion (`localStorage`, not `sessionStorage`) rests on the key and
API used rather than on a run, for the same reason as #13: no .NET SDK here. The store
adapter is four lines around `supercompStorage.read/write/remove`; everything with logic
in it is tested.

This closes Phase 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_