### PR TITLE
Publish the WebAssembly app to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,137 @@
+name: Deploy GitHub Pages
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The README's only instruction for seeing this application was `dotnet run`, which
+# limits the audience for a visualisation tool to people with a .NET 8 SDK installed.
+# That is the wrong shape for what this is: a client-only WebAssembly app with no server,
+# no database and no secrets, whose entire output is a picture. It compiles to static
+# files and can simply be hosted.
+#
+# The build job also runs on pull requests. That is deliberate: a deploy-only workflow
+# cannot be validated before it is merged, so its first real execution would be on
+# master, where a failure is already published. Building the artifact on the PR proves
+# the publish, the base-href rewrite, the SPA fallback and .nojekyll before any of it
+# matters.
+#
+# ONE-TIME MANUAL PREREQUISITE this workflow cannot do for itself:
+#   Settings -> Pages -> Source must be set to "GitHub Actions".
+# Without it actions/deploy-pages has nowhere to deploy and fails with no alternative.
+# That is not a code failure and should not consume the retry budget.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  DOTNET_VERSION: "8.0.x"
+  DOTNET_NOLOGO: "true"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  # A project page is served from /<repo>/, not from /. Every asset path and every Blazor
+  # route resolves against <base href>, so this is the difference between the app and a
+  # blank page.
+  BASE_HREF: "/SupercompensationApp/"
+
+jobs:
+  build:
+    name: Build Pages artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Publish
+        run: dotnet publish SupercompensationApp.csproj -c Release -o publish
+
+      # Rewritten here rather than in the committed file, so `dotnet run` keeps working
+      # locally. wwwroot/index.html carries a matching comment saying the two are linked.
+      #
+      # The grep is not decoration. If the committed <base href> is ever reformatted this
+      # sed silently matches nothing, the published app resolves every asset against the
+      # wrong root, and the symptom is a blank page with no failed step. Failing here is
+      # the whole point of the check.
+      - name: Rewrite base href for the project page
+        run: |
+          set -euo pipefail
+          index=publish/wwwroot/index.html
+          grep -q '<base href="/" />' "$index" || {
+            echo "::error::Could not find the expected <base href=\"/\" /> in $index."
+            echo "The committed index.html has changed shape; update this workflow with it."
+            exit 1
+          }
+          sed -i "s|<base href=\"/\" />|<base href=\"${BASE_HREF}\" />|" "$index"
+          grep -q "<base href=\"${BASE_HREF}\" />" "$index" || {
+            echo "::error::base href rewrite did not take effect."
+            exit 1
+          }
+          echo "base href is now: $(grep -o '<base href=\"[^\"]*\" />' "$index")"
+
+      # GitHub Pages has no SPA rewrite, so a deep link to /chart or /data — and any
+      # refresh on those routes — returns 404. A copy of index.html is the standard
+      # answer, and it MUST be made after the rewrite above or it carries the wrong base.
+      - name: Add the SPA fallback
+        run: |
+          set -euo pipefail
+          cp publish/wwwroot/index.html publish/wwwroot/404.html
+          grep -q "<base href=\"${BASE_HREF}\" />" publish/wwwroot/404.html
+
+      # Jekyll strips directories beginning with an underscore, and the Blazor runtime
+      # lives in _framework/. Without this the deploy succeeds and the app does not start.
+      - name: Disable Jekyll
+        run: touch publish/wwwroot/.nojekyll
+
+      - name: Check the artifact is actually complete
+        run: |
+          set -euo pipefail
+          for required in \
+            publish/wwwroot/index.html \
+            publish/wwwroot/404.html \
+            publish/wwwroot/.nojekyll \
+            publish/wwwroot/_framework/blazor.boot.json \
+            publish/wwwroot/js/chart-interop.js \
+            publish/wwwroot/js/storage-interop.js \
+            publish/wwwroot/css/app.css
+          do
+            test -f "$required" || { echo "::error::missing $required"; exit 1; }
+          done
+          echo "artifact contents look right:"
+          du -sh publish/wwwroot
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: publish/wwwroot
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    # Pull requests build the artifact but must not publish it.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Bieżący postęp: [tracker #18](https://github.com/konradcinkusz/Supercompensat
 
 ## Uruchomienie
 
+**Wersja online:** https://konradcinkusz.github.io/SupercompensationApp/
+
+Publikowana automatycznie z gałęzi `master`. Nie wymaga instalacji .NET — wystarczy
+przeglądarka z obsługą WebAssembly i dostęp do sieci (biblioteki wykresu ładowane są z CDN).
+
+Lokalnie:
+
 ```bash
 cd SupercompensationApp
 dotnet restore

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Supercompensation Model — Agile Sprint Visualizer</title>
+    <!-- Correct for `dotnet run`, and REWRITTEN AT PUBLISH TIME by
+         .github/workflows/pages.yml, because a project page is served from
+         /SupercompensationApp/ rather than from /. Every asset path and every Blazor
+         route resolves against this, so the two must move together — the workflow greps
+         for this exact line and fails loudly if it stops matching, since the symptom
+         otherwise is a blank published page with no failed step. -->
     <base href="/" />
     <link href="css/app.css" rel="stylesheet" />
 


### PR DESCRIPTION
Closes #15

## What changed

- `.github/workflows/pages.yml` — publish, fix up, verify, deploy.
- `wwwroot/index.html` — a comment linking `<base href>` to the workflow that rewrites it.
- `README.md` — links the live app.

## Why

The README's only instruction for seeing this application was `dotnet run`, which limits
the audience for a *visualisation tool* to people with a .NET 8 SDK installed. It is
client-only — no server, no database, no secrets — and compiles to static files.

## The build job runs on pull requests, and that is the point

A deploy-only workflow **cannot be validated before it is merged**: its first real
execution would be on `master`, where a failure is already published. So `build` runs on
PRs too and `deploy` is guarded with `if: github.event_name != 'pull_request'`.

That means the publish, the base-href rewrite, the SPA fallback and `.nojekyll` are all
proved on **this page**, before any of it matters.

## Three things a plain publish gets wrong

| | Why | Symptom if skipped |
|---|---|---|
| `<base href>` → `/SupercompensationApp/` | A project page is served from `/<repo>/`, and every asset path and Blazor route resolves against it | blank page |
| `404.html` = copy of `index.html` | Pages has no SPA rewrite | deep link or refresh on `/chart` → 404 |
| `.nojekyll` | Jekyll strips `_`-prefixed directories, and the runtime is in `_framework/` | deploy succeeds, app never starts |

The `404.html` copy is made **after** the rewrite, or it carries the wrong base — the
issue calls this out and it is the step most often done in the wrong order.

The base href is rewritten **in the workflow, not in the committed file**, so `dotnet run`
keeps working locally. `index.html` now carries a comment saying the two are linked.

## The greps are not decoration

The rewrite step greps for the expected line **before** the `sed` and for the result
**after** it. If the committed `<base href>` is ever reformatted, the substitution silently
matches nothing, every asset resolves against the wrong root, and the symptom is a blank
page **with no failed step** — precisely the class of defect this repository keeps finding
(the invisible chart title, the misplaced phase bands, the CSV that opens without an
error). Failing loudly there is the whole point.

A final step asserts the artifact actually contains `index.html`, `404.html`, `.nojekyll`,
`_framework/blazor.boot.json`, both interop scripts and the stylesheet.

## Two known risks, flagged rather than discovered

**This is the first live exercise of the SRI hashes from #4.** jsDelivr is unreachable
through this environment's proxy, so those `integrity` attributes have never been served to
a browser. If the deployed page loads but the chart is blank, that is where to look first —
a wrong hash makes the browser refuse the script silently.

**`TreatWarningsAsErrors` meets trimming here.** `Directory.Build.props` (from #6) carries
a note for exactly this moment: `dotnet build` is safe, but Blazor WebAssembly turns on
trimming during `dotnet publish -c Release` and the ILLink analyzer emits `IL2xxx`
warnings that this setting would promote to errors. If the Publish step goes red on
trimming rather than on real code, the recorded remedy is to add the specific IDs to
`WarningsNotAsErrors` — **scope it, do not delete it**. I have deliberately not guessed at
IDs in advance; if it fires, the log names them.

## Manual prerequisite

**Settings → Pages → Source must be set to "GitHub Actions"**, and the repository must be
public or on a plan that allows Pages. `actions/deploy-pages` fails with no alternative
otherwise. That is a configuration fact, not a code failure, and per the issue it should be
recorded rather than retried — it must not consume the three-attempt budget.

## Protected path

`.github/workflows/**` (`ROADMAP.md` §5) — not force-mergeable after three failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_