### PR TITLE
Document the model's assumptions and limits

### DIFF
--- a/Pages/Chart.razor
+++ b/Pages/Chart.razor
@@ -62,7 +62,13 @@
                             <span class="stat-value min">@summary.MinPerformance.ToString("F1")</span>
                         </div>
                         <div class="stat">
-                            <span class="stat-label">Delivery Value</span>
+                            @* The odd one out on this card, and labelled as such. Baseline,
+                               Peak and Min are instantaneous; Delivery value is an
+                               INTEGRAL over sprint days, so it scales with sprint length
+                               while the other three do not. Three numbers side by side,
+                               two of them rates and one an accumulation, is exactly the
+                               arrangement that invites reading it as a fourth rate. *@
+                            <span class="stat-label">Delivery value <em>(wyd. × dni)</em></span>
                             <span class="stat-value dv">@summary.DeliveryValue.ToString("F2")</span>
                         </div>
                     </div>

--- a/README.md
+++ b/README.md
@@ -47,19 +47,92 @@ Aplikacja uruchomi się na `http://localhost:5171`
 
 ## Model matematyczny
 
-Krzywa superkompensacji dla jednego sprintu (znormalizowane dni 0→1):
+Krzywa superkompensacji dla jednego sprintu, gdzie `s` ∈ [0, 1] to postęp sprintu:
 
-| Faza               | Dni (%)  | Wzór                        |
-|---------------------|----------|------------------------------|
-| Fatigue             | 0 → 50% | `−D · t²`                   |
-| Recovery            | 50 → 80%| `−D · (1−t)²`               |
-| Supercompensation   | 80 → 100%| `P · sin(t · π/2)`         |
+| Faza               | `s`        | Wzór              | `t` w tym wzorze     |
+|---------------------|------------|-------------------|----------------------|
+| Fatigue             | 0 → 50%    | `−D · t²`         | `t = s / 0,5`        |
+| Recovery            | 50 → 80%   | `−D · (1−t)²`     | `t = (s − 0,5) / 0,3`|
+| Supercompensation   | 80 → 100%  | `P · sin(t · π/2)`| `t = (s − 0,8) / 0,2`|
 
-Gdzie: `D` = głębokość zmęczenia, `P` = szczyt superkompensacji
+**`t` jest inne w każdym wierszu** i biegnie od 0 do 1 *wewnątrz danej fazy* — to nie
+jest ten sam `t` co postęp sprintu. Rozróżnienie ma znaczenie: przy `s = 0,5` wzór
+`−D · s²` dałby `−6,25`, podczas gdy dołek krzywej wynosi dokładnie `−D = −25`.
 
-**Progresywny baseline:** `B(n) = B₀ + n × ΔB`
+Gdzie: `D` = głębokość zmęczenia (parametr), `P` = szczyt superkompensacji (parametr).
+
+**Granice faz — 50% i 80% — są stałymi modelu, nie parametrami.** Są zapisane w kodzie
+jako właściwości bez settera (`SprintConfiguration.FatiguePhaseEnd`,
+`RecoveryPhaseEnd`) i nie da się ich zmienić bez edycji źródeł.
+
+**Progresywny baseline:** `B(n) = B₀ + n × ΔB`, gdzie `n` liczone od zera.
 
 **Wydajność:** `Performance(d) = (B(sprint) + deviation(d)) × W_team`
+
+### Zakresy parametrów
+
+Wymuszane przez aplikację — wartość spoza zakresu blokuje przycisk generowania i jest
+wypisana pod nim. Ograniczenia `min`/`max` w HTML są jedynie podpowiedzią i nie
+powstrzymują wklejenia wartości, dlatego walidacja żyje w modelu.
+
+| Parametr | Zakres |
+|---|---|
+| Czas trwania sprintu | 5 – 30 |
+| Liczba sprintów | 1 – 20 |
+| Przyrost baseline | 0 – 50 |
+| Początkowy baseline | 50 – 200 |
+| Głębokość zmęczenia | 5 – 50 |
+| Szczyt superkompensacji | 5 – 40 |
+
+## Założenia i ograniczenia
+
+Model jest prosty i przekonująco wygląda na wykresie. To jest lista rzeczy, których
+wykres **nie mówi**, a bez których łatwo odczytać go źle.
+
+**1. Waga zespołu to SUMA, nie średnia.** `CalculateTeamWeight` zwraca sumę wag
+członków, więc dodanie osoby mnoży *każdą* liczbę na wykresie. Domyślny
+siedmioosobowy zespół daje wagę `6,35`; ten sam model dla jednej osoby o wadze `1,0`
+daje liczby 6,35 raza mniejsze. **Porównując dwie konfiguracje zespołu, różnicę w
+liczebności odczytasz jako różnicę w produktywności.** Oś Y jest opisana „wydajność
+zespołu (ważona)” i to jest właśnie ta ważona suma.
+
+**2. Krzywa skacze na granicy każdego sprintu.** Sprint kończy się `P` powyżej swojej
+linii bazowej, a następny zaczyna się `0` powyżej linii wyższej o `ΔB`. Przy
+domyślnych wartościach (`P = 18`, `ΔB = 15`) wydajność **spada o 19,05** przez noc:
+
+```
+koniec sprintu 1   = (100 + 18) × 6,35 = 749,30
+początek sprintu 2 = (115 +  0) × 6,35 = 730,25
+```
+
+To jest **świadoma własność modelu**, nie przeoczenie: superkompensacja wygasa, jeśli
+nie zostanie wykorzystana jako nowa baza. Ale z samego wykresu nie da się odróżnić
+decyzji od błędu, więc jest zapisana tutaj.
+
+**3. `Delivery value` to całka, a nie tempo.** To pole powierzchni między krzywą a
+linią bazową w fazie superkompensacji, w jednostkach *wydajność × dni*. Na karcie
+podsumowania stoi obok `Peak` i `Min`, które są wartościami chwilowymi — trzy liczby w
+jednym miejscu, z których dwie są tempem, a jedna akumulacją. **Podwojenie długości
+sprintu podwaja `Delivery value` i nie zmienia pozostałych dwóch:**
+
+| Czas trwania sprintu | Delivery value | Na dzień |
+|---|---|---|
+| 5 | 74,19 | 14,84 |
+| 10 | 148,37 | 14,84 |
+| 20 | 296,74 | 14,84 |
+| 30 | 445,11 | 14,84 |
+
+**4. Granice faz są stałe.** Patrz wyżej: 50% i 80% nie są parametrami. Tabela modelu
+w starszych wersjach tego pliku prezentowała je obok `D` i `P`, co sugerowało pokrętło,
+którego nie ma.
+
+**5. Aplikacja wymaga sieci.** Chart.js i wtyczka `chartjs-plugin-annotation` są
+ładowane z `cdn.jsdelivr.net` (z sumami kontrolnymi SRI). Bez dostępu do sieci
+aplikacja uruchomi się, ale wykres się nie narysuje. Nie działa offline.
+
+**Czego ten model nie jest.** Nie jest wynikiem pomiaru żadnego zespołu. To wizualizacja
+kształtu, o którym mówi teoria superkompensacji, z parametrami, które ustawiasz sam —
+przydatna do rozmowy o tym kształcie, a nie do przewidywania czyjejkolwiek wydajności.
 
 ## Technologie
 

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -358,6 +358,14 @@ html, body {
 /* Shown when the chart on screen was generated from inputs the user has since edited.
    Before the state moved into a service this was silent: ResetTeam reassigned the list
    while the chart still described the previous team. */
+/* The unit qualifier on a summary stat label. Delivery value is in wydajność x dni
+   while its neighbours are instantaneous, and the card gives no other clue. */
+.stat-label em {
+    font-style: normal;
+    opacity: 0.7;
+    font-size: 0.85em;
+}
+
 .stale-notice {
     margin: 0 0 1rem 0;
     padding: 0.75rem 1rem;


### PR DESCRIPTION
Closes #16

## What changed

- `README.md` — corrected model table, parameter ranges, and a new
  *Założenia i ograniczenia* section.
- `Pages/Chart.razor` + `app.css` — `Delivery value` now carries its unit.

## Why

The README stated the model as three formulas, which is accurate as far as it goes. What
it did not say is what the model **assumes** — and for a tool whose entire output is a
persuasive-looking curve about team performance, the assumptions are the part a reader
needs in order to use it honestly.

## A fifth defect, found while checking the four

The old table was **wrong**, not merely incomplete. It presented a single `t` across three
rows:

| Faza | Dni (%) | Wzór |
|---|---|---|
| Fatigue | 0 → 50% | `−D · t²` |

But `t` is **re-normalised within each phase**. At sprint fraction `0.5` the table as
written gives `−6.25`; the actual trough is exactly `−D = −25`. A reader working the
formula by hand gets a different curve from the one on screen.

The table now names each row's `t` separately (`s/0.5`, `(s−0.5)/0.3`, `(s−0.8)/0.2`) and
states the discrepancy so the correction is checkable rather than silent.

## The four the issue named, with the numbers

**Team weight is a SUM, not a mean.** The default seven-person team gives `6.35`; the same
model with one person at `1.0` gives numbers **6.35× smaller**. Anyone comparing two team
configurations reads a difference in headcount as a difference in productivity.

**The curve jumps at every sprint boundary.** A sprint ends `P` above its baseline; the
next starts `0` above a baseline `ΔB` higher:

```
koniec sprintu 1   = (100 + 18) × 6,35 = 749,30
początek sprintu 2 = (115 +  0) × 6,35 = 730,25      → −19,05 across midnight
```

The README says this is a **deliberate property** — supercompensation decays if it is not
built on — precisely because the chart cannot distinguish a modelling decision from an
oversight.

**`Delivery value` is an integral.** In *wydajność × dni*, sitting on a card beside `Peak`
and `Min`, which are instantaneous. Three numbers side by side, two rates and one
accumulation:

| SprintDuration | Delivery value | per day |
|---|---|---|
| 5 | 74.19 | 14.84 |
| 10 | 148.37 | 14.84 |
| 20 | 296.74 | 14.84 |
| 30 | 445.11 | 14.84 |

The card now shows the unit, with a comment explaining why that stat and not its
neighbours.

**Phase boundaries are fixed constants.** `FatiguePhaseEnd` and `RecoveryPhaseEnd` are
expression-bodied with no setter and cannot be changed without editing source. The old
table presented them alongside `D` and `P`, implying a knob that does not exist.

**Plus the dependency the README omitted entirely:** the chart libraries load from
`cdn.jsdelivr.net`, so the application does **not work offline**.

## Also

Parameter ranges are now documented, since #11 made them enforced rather than advisory.

And a closing paragraph says what the model **is not**: it is not the result of measuring
any team. That is the sentence a reader most needs and the one a chart is least able to
say for itself.

## Verification

REPO-BASELINE §8 makes a stale README a review finding, so every claim was re-checked
against the source **as it stands at the time of this PR**, not against the issue text —
#9, #10, #11 and #15 all changed behaviour the README describes, which is why this issue
was sequenced after them.

```
OK   FatiguePhaseEnd has no setter        OK   NumberOfSprints range 1-20
OK   RecoveryPhaseEnd has no setter       OK   InitialBaseline range 50-200
OK   team weight is a Sum                 OK   FatigueDepth range 5-50
OK   SprintDuration range 5-30            OK   Peak range 5-40
OK   BaselineIncrement range 0-50         OK   DeliveryValue multiplies by dt
ALL VERIFIED
```

The inter-sprint jump, the delivery-value scaling and the `t` discrepancy were each
computed rather than reasoned about.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_