### PR TITLE
Add CONTRIBUTING.md and a README dependency table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing
+
+Small repository, short guide. The one thing worth reading before you push is
+[Reproducing CI locally](#reproducing-ci-locally) — the format gate is the check most
+likely to fail on a first contribution and the least obvious to run.
+
+## Prerequisites
+
+- **.NET 8 SDK.** The project targets `net8.0` and CI pins `8.0.x`. A newer SDK will
+  build it, but pinning is what makes a green build here mean the same thing next month.
+- **A browser with WebAssembly** — anything current.
+- **Network access at runtime.** Chart.js and `chartjs-plugin-annotation` load from
+  `cdn.jsdelivr.net`. The application starts offline; the chart does not draw. This is
+  not obvious from the source and it is why it is the second item on this list.
+- **Docker**, only if you want to run the secret scanner locally. Everything else needs
+  the SDK alone.
+
+Nothing here needs a credential, a token or an environment variable. This application has
+none, and it should stay that way.
+
+## Running it
+
+```bash
+dotnet restore
+dotnet run
+```
+
+`http://localhost:5171`, or `https://localhost:7171`.
+
+A live build is published from `master`:
+https://konradcinkusz.github.io/SupercompensationApp/
+
+## Running the tests
+
+```bash
+dotnet test SupercompensationApp.sln
+```
+
+Tests live in `tests/SupercompensationApp.Tests/`. What is there and why:
+
+| File | Pins |
+|---|---|
+| `SupercompensationCurveTests` | phase boundaries, continuity at the joins, endpoints, monotonicity, the aggregates |
+| `SprintConfigurationValidationTests` | every parameter range, both directions, plus NaN and the infinities |
+| `CsvExporterTests` | the export is byte-identical under `pl-PL`, `de-DE` and `en-US` |
+| `AppStateServiceTests` | state, staleness, team membership, change notification |
+| `StatePersistenceTests` | the storage round trip and every fail-soft path |
+
+Two conventions in these tests, both load-bearing:
+
+- **Assert the invariant, not the observation.** A measured floating-point residual is a
+  property of the machine that measured it. `SupercompensationCurveTests` derives its
+  continuity bound from the curve's own maximum slope rather than committing a number,
+  and the derivation is in a comment so the next person can check it.
+- **A check that cannot fail is not a check.** `CsvExporterTests` contains a test that
+  asserts `pl-PL` really does format a decimal with a comma — because without ICU,
+  `new CultureInfo("pl-PL")` silently yields invariant behaviour and every other test in
+  that file would pass while never exercising a second culture.
+
+## Reproducing CI locally
+
+**Every command below is the one CI runs**, minus flags that exist only to produce CI
+artifacts — the test command drops `--logger trx` and `--results-directory`, which you do
+not want locally.
+
+That matters more than it sounds. These are not commands somebody ran once on their
+machine and wrote down: they are executed on every push, so if one of them drifts, CI goes
+red and this file is wrong in a way somebody will notice. A contributing guide with an
+untested command is the same defect as a committed-but-never-executed config.
+
+| CI check | Run it locally |
+|---|---|
+| **CI / Build** | `dotnet restore SupercompensationApp.sln`<br>`dotnet build SupercompensationApp.sln --no-restore --configuration Release`<br>`dotnet test SupercompensationApp.sln --no-build --configuration Release` |
+| **CI / Format check** | `dotnet format SupercompensationApp.sln --verify-no-changes --severity error` |
+| **Secret scan / gitleaks** | `docker run --rm -v "$PWD:/repo" -w /repo zricethezav/gitleaks:v8.28.0 git /repo --config=/repo/.gitleaks.toml --redact --no-banner --verbose` |
+| **Deploy GitHub Pages / Build** | `dotnet publish SupercompensationApp.csproj -c Release -o publish` |
+| **CodeQL** | Not reproducible locally without the CodeQL CLI; it runs on every pull request. |
+
+### If the format check fails
+
+`--verify-no-changes` tells you *which* files would change and roughly where, which is
+enough to find a stray space and not enough to fix a reindented block. Apply the fix and
+read the diff:
+
+```bash
+dotnet format SupercompensationApp.sln --severity error
+git diff
+```
+
+CI does exactly this in an `if: failure()` step, so a red run already carries the diff it
+wants — check the log before reproducing it.
+
+**Two things `dotnet format` does not cover**, so a green format check is not a claim
+about them: it operates on Roslyn compilation units, so the `.razor` files and
+`wwwroot/js/*.js` are untouched by it. The JavaScript is analysed by CodeQL; the Razor is
+reviewed by people.
+
+## Protected paths
+
+These gate every *other* pull request, so breaking one is not contained. A change to any
+of them is not force-merged over a red CI run — see [`ROADMAP.md`](ROADMAP.md) §5–6.
+
+- `.github/workflows/**`
+- `SupercompensationApp.csproj`, `SupercompensationApp.sln`
+- `Directory.Build.props`, `Directory.Packages.props`
+- `.editorconfig` — the format gate reads it, so it decides whether every PR is green
+- `.gitleaks.toml`
+
+`.github/CODEOWNERS` names the same set, so GitHub asks for a review on them.
+
+Two of these have a trap worth knowing in advance:
+
+- **`.editorconfig` entries are assertions about every existing file.** The first version
+  of it set `csharp_preserve_single_line_statements = false`, which is not the Roslyn
+  default and contradicted `GetPhase`'s three parallel guard clauses. CI rejected it. The
+  fix was the setting, not the source.
+- **Package versions live in `Directory.Packages.props`**, not in the `.csproj`. A
+  `Version=` attribute on a `PackageReference` is an error under central package
+  management.
+
+## Pull requests
+
+One issue, one pull request. Conventions taken from what this repository's merged history
+actually shows:
+
+- **Imperative subject, roughly 40–85 characters**, naming the change rather than the
+  area: *Make the CSV export culture-invariant*, not *CSV fixes*.
+- Where a subject names a defect, it says what was wrong: *Give the chart a linear x axis:
+  phase bands and sprint boundaries were misplaced.*
+- **The body explains why, and what was measured.** This codebase has a run of defects
+  that were invisible in a diff — a chart title painted in its own background colour, a
+  CSV that opens in every spreadsheet without an error, phase bands misplaced by a factor
+  of five. "How it was verified" is the section reviewers need most.
+- `Closes #N`.
+- The PR template asks whether the change touches a protected path. It matters; answer it.
+
+## Reporting a bug
+
+Use the issue template — it asks for two things a generic one would not, and both earn
+their place:
+
+- **The sprint parameters.** Several defects here are *ratios* rather than constants and
+  are invisible at one configuration while wrong at another.
+- **Your locale.** Blazor WebAssembly takes its culture from the browser, and a decimal
+  comma has already broken the CSV export once. The template gives the console snippet
+  that reports it.

--- a/README.md
+++ b/README.md
@@ -134,12 +134,62 @@ aplikacja uruchomi się, ale wykres się nie narysuje. Nie działa offline.
 kształtu, o którym mówi teoria superkompensacji, z parametrami, które ustawiasz sam —
 przydatna do rozmowy o tym kształcie, a nie do przewidywania czyjejkolwiek wydajności.
 
-## Technologie
+## Technologie i zależności
 
 - .NET 8 Blazor WebAssembly
-- Chart.js 4.4 + chartjs-plugin-annotation
-- JS Interop dla wykresów
-- Czysty CSS (dark theme, responsive)
+- JS Interop dla wykresu i dla `localStorage`
+- Czysty CSS (dark theme, responsive) — bez frameworka
+
+Pełna lista zależności zewnętrznych. Liczba w tej tabeli, która rośnie w diffie, jest
+pytaniem, które ktoś może zadać; tabela, której nikt nie aktualizuje, jest widocznie
+nieaktualna.
+
+**NuGet** — wersje w `Directory.Packages.props`, aktualizowane przez Dependabota:
+
+| Pakiet | Wersja | Po co |
+|---|---|---|
+| `Microsoft.AspNetCore.Components.WebAssembly` | 8.0.12 | środowisko uruchomieniowe aplikacji |
+| `Microsoft.AspNetCore.Components.WebAssembly.DevServer` | 8.0.12 | tylko `dotnet run` (`PrivateAssets`) |
+| `Microsoft.NET.Test.Sdk` | 17.11.1 | tylko testy |
+| `xunit` | 2.9.2 | tylko testy |
+| `xunit.runner.visualstudio` | 2.8.2 | tylko testy |
+| `coverlet.collector` | 6.0.2 | tylko testy |
+
+**CDN** — ładowane w `wwwroot/index.html`. **Dependabot ich nie widzi**: nie czyta
+znaczników `<script>` w HTML, więc nic nie zgłosi, gdy się zestarzeją. Wersję i sumę
+kontrolną trzeba zmieniać razem — błędna suma sprawia, że przeglądarka po cichu odrzuca
+skrypt, a objawem jest pusty wykres, nie błąd.
+
+| Skrypt | Wersja | `integrity` (sha384) |
+|---|---|---|
+| `chart.js` (`dist/chart.umd.js`) | 4.4.1 | `dug+JxfBvklEQdJ4AYuBBAIScUz0bVN73xpy273gcAwHjb3qI0fXmuYNaNfdyYJG` |
+| `chartjs-plugin-annotation` | 3.0.1 | `oNtu+d18330MVFpltUTve1DatxCkkctlpA2AC3GulbVFOSqhHdDat3qHse/Lbuek` |
+
+`chart.js` wskazuje `dist/chart.umd.js`, a nie `chart.umd.min.js`: wersja 4.4.1 **nie
+publikuje** pliku zminifikowanego — `.min.js` generuje jsDelivr w locie, więc suma
+kontrolna dotyczyłaby bajtów, których autor pakietu nigdy nie opublikował. `chart.umd.js`
+i tak jest budową zminifikowaną, tylko bez `.min` w nazwie.
+
+Trzecia zależność niewidoczna dla Dependabota: obraz `zricethezav/gitleaks:v8.28.0`
+przypięty wewnątrz kroku `run:` w `.github/workflows/secret-scan.yml`.
+
+## Rozwój
+
+Szczegóły w [`CONTRIBUTING.md`](CONTRIBUTING.md) — jak uruchomić, jak testować i jak
+odtworzyć każdy job CI lokalnie.
+
+Na każdy pull request uruchamiane są:
+
+| Job | Co sprawdza |
+|---|---|
+| **CI / Build** | `dotnet restore`, `build -c Release`, `dotnet test` |
+| **CI / Format check** | `dotnet format --verify-no-changes --severity error` |
+| **Secret scan / gitleaks** | całą historię, nie tylko drzewo robocze |
+| **CodeQL** | `csharp` oraz `javascript-typescript` |
+| **Deploy GitHub Pages / Build** | że artefakt publikacji faktycznie się składa |
+
+Ścieżki chronione — pliki, których uszkodzenie psuje **każdy** kolejny pull request — są
+wypisane w [`ROADMAP.md`](ROADMAP.md) §5 i w `.github/CODEOWNERS`.
 
 ## Wymagania
 


### PR DESCRIPTION
Closes #17

## What changed

- `CONTRIBUTING.md` — new.
- `README.md` — a dependency table and a Development section naming the CI jobs.

## Why

The repository now carries four workflows, a test project, central package management and
an `.editorconfig`-backed format gate, and **none of it was discoverable from the README**.
The first outside contribution — or the first session after a gap — rediscovers it by
pushing and reading a red build.

## The commands are the ones CI runs, and that is checked

Not "commands somebody ran once and wrote down". Every command in the reproduce-CI table
is what a workflow executes on every push, minus the flags that only exist to produce CI
artifacts (`--logger trx`, `--results-directory`). If one drifts, CI goes red and this file
is visibly wrong.

Verified mechanically rather than by eye — each quoted command matched against the
workflow files, honouring shell line continuations:

```
contrib=Y workflow=Y  dotnet restore SupercompensationApp.sln
contrib=Y workflow=Y  dotnet build ... --no-restore --configuration Release
contrib=Y workflow=Y  dotnet test ... --no-build --configuration Release
contrib=Y workflow=Y  dotnet format ... --verify-no-changes --severity error
contrib=Y workflow=Y  dotnet format ... --severity error
contrib=Y workflow=Y  dotnet publish ... -c Release -o publish
contrib=Y workflow=Y  zricethezav/gitleaks:v8.28.0 git /repo
EVERY QUOTED COMMAND IS A PREFIX OF ONE CI ACTUALLY RUNS
```

My first pass at this check reported drift on the test command. It was the **checker** that
was wrong — `ci.yml` writes that command across `\`-continued lines — but it did surface a
real overclaim: I had written *"copied verbatim"*, and the local form deliberately drops two
CI-only flags. The wording now says which flags and why.

## The dependency table

REPO-BASELINE §4b: *"a number that goes up in a diff is a question somebody can ask, and a
table nobody updates is visibly stale."*

Six NuGet packages, and — more usefully — **the three dependencies Dependabot cannot see**:

| Invisible to Dependabot | Why |
|---|---|
| `chart.js` 4.4.1 | it does not read HTML `<script>` tags |
| `chartjs-plugin-annotation` 3.0.1 | same |
| `zricethezav/gitleaks:v8.28.0` | an image reference inside a `run:` step is an opaque string |

Both `integrity` hashes are in the table with the warning that version and hash move
together — a wrong hash makes the browser refuse the script *silently*, and the symptom is
a blank chart rather than an error.

It also records why `chart.js` points at `dist/chart.umd.js` rather than
`chart.umd.min.js`: 4.4.1 publishes no minified file, so jsDelivr generates `.min.js` on
demand and a hash of it would cover bytes the package author never published.

**Every version and both hashes were checked against `Directory.Packages.props` and
`index.html`** rather than transcribed — all 11 checks pass.

## What else is in CONTRIBUTING

- **Prerequisites**, including one the source does not reveal: the app needs **network
  access at runtime**, because the chart libraries are CDN-loaded. It starts offline; the
  chart does not draw.
- **The protected paths**, cross-checked against `ROADMAP.md` §5 (none missing), plus the
  two traps that have already cost a CI round here: an `.editorconfig` entry is an
  assertion about *every existing file*, and a `Version=` attribute on a `PackageReference`
  is an error under central package management.
- **What the format check does *not* cover** — `.razor` and `wwwroot/js/*.js` — so a green
  tick is not read as a claim about them.
- **Two test conventions** that are load-bearing rather than stylistic: assert the
  invariant rather than the observation, and a check that cannot fail is not a check.
- **PR conventions taken from the merged history**, not invented: imperative subjects of
  roughly 40–85 characters that name the change, and a body whose most useful section is
  *how it was verified* — because this codebase has a run of defects that were invisible in
  a diff.

## Verification

- 11/11 documented versions and hashes match their source of truth.
- 7/7 quoted CI commands match a workflow.
- 0 protected paths from ROADMAP §5 missing from CONTRIBUTING.
- Neither document mentions a credential, token or environment variable. This application
  has none, and a guide inviting one is how that stops being true.

This is the last issue in the roadmap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_