### PR TITLE
Bump the GitHub Actions to clear the Node 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       # them.
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-results
           path: "**/TestResults/*.trx"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
     # GitHub's default and not a number anybody chose. This build takes about a minute.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -91,10 +91,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       # them.
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: "**/TestResults/*.trx"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,17 +51,17 @@ jobs:
             build-mode: none
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           # Kept in step with ci.yml and with SupercompensationApp.csproj's net8.0.
           dotnet-version: "8.0.x"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -78,6 +78,6 @@ jobs:
           dotnet build SupercompensationApp.sln --no-restore --configuration Release
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history. A secret removed in the tip commit is still a leaked secret,
           # and scanning only the working tree would call that clean.


### PR DESCRIPTION
Closes #42

## What changed

Twelve action pins across all four workflows:

| Action | | Call sites |
|---|---|---|
| `actions/checkout` | v4 → **v7** | 5 |
| `actions/setup-dotnet` | v4 → **v6** | 4 |
| `github/codeql-action/init` | v3 → **v4** | 1 |
| `github/codeql-action/analyze` | v3 → **v4** | 1 |
| `actions/upload-artifact` | v4 → **v7** | 1 |

## Why

Every job has logged the same warning since CI landed:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to
run on Node.js 24: actions/checkout@v4, actions/setup-dotnet@v4, ...
```

The point is **readability**, not tidiness. A warning nobody has to act on is one everybody
learns to scroll past — the argument that put `TreatWarningsAsErrors` in
`Directory.Build.props` — and reading job logs carefully is how most of this repository's
defects were found.

## It took three passes, and that is the interesting part

The acceptance criterion was *"the warning is gone from the logs — verify by reading a job
log, not by assuming."* I read one after each push, and twice it was **not gone**:

| Pass | Pinned | Log said |
|---|---|---|
| 1 | checkout/setup-dotnet/codeql bumped; `upload-artifact@v4` left alone | `... target Node.js 20: actions/upload-artifact@v4` |
| 2 | `upload-artifact@v5` | `... target Node.js 20: actions/upload-artifact@v5` |
| 3 | `upload-artifact@v7` | **no warning at all** |

Two wrong beliefs, each corrected by the log rather than by me noticing:

- **Pass 1** rested on *"Dependabot did not flag it, which is evidence it is current."* That
  inference is wrong. Dependabot simply had not opened that PR yet.
- **Pass 2** rested on a release description saying v5 "updates the runtime to Node.js 24".
  v5 has only **preliminary** Node 24 support and still defaults to Node 20;
  `runs.using: node24` landed in **v6.0.0**.

**None of this was a CI failure** — every check has been green on all three pushes, so the
three-attempt cap in `ROADMAP.md` §6 is untouched. What kept failing was an acceptance
criterion CI does not measure. That is the whole reason the criterion said to read a log: a
green build that has not achieved the thing the change was for looks identical to one that
has.

## One warning remains, and it is not mine to fix

The **Build Pages artifact** job still reports:

```
... target Node.js 20 ...: actions/upload-artifact@v4
```

`pages.yml` does not reference `upload-artifact` anywhere:

```
$ grep -n 'upload-artifact' .github/workflows/pages.yml
  (no match)
$ grep -nE 'uses: actions/(upload|deploy)' .github/workflows/pages.yml
  116:  uses: actions/upload-pages-artifact@v3
  137:  uses: actions/deploy-pages@v4
```

It arrives **transitively**: `upload-pages-artifact@v3` is a composite action that pins
`upload-artifact@v4` internally. **v3 is its current release**, so there is no version of it
I can move to. Clearing this needs an upstream release, or abandoning the official Pages
action — neither of which belongs in a version bump.

Recorded rather than papered over. `deploy-pages@v4` is likewise current.

## Verification

- All four workflows parse; no stale pin left behind.
- Every check green — including **Analyze (csharp)** under the CodeQL v4 major, which was
  the most likely thing here to break, and **Build Pages artifact** under `setup-dotnet@v6`.
- **The `ci.yml` Build job log now ends with process cleanup and no `##[warning]` line at
  all.** That is the criterion, met and read.

Dependabot's #27, #28 and #29 are deliberately left open — it closes them itself once it
sees each dependency already at the target version.

## Protected path

`.github/workflows/**` (`ROADMAP.md` §5) — not force-mergeable after three CI failures.
There were none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo