### PR TITLE
Bump upload-pages-artifact to v5 and assert .nojekyll survives the tar

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -167,10 +167,59 @@ jobs:
           path: tests/e2e/artifacts/
           if-no-files-found: warn
 
+      # v5 rather than v3 for two reasons, and the second is the one that needs the
+      # input below.
+      #
+      # v3 bundles actions/upload-artifact@v4, which is the last Node 20 action in this
+      # repository and the only remaining source of the deprecation warning #42 set out
+      # to clear. v5 bundles v7, which is what our own upload steps use.
+      #
+      # And v4 changed the tar to be built with `--exclude=.[^/]*`, so DOTFILES ARE
+      # DROPPED unless include-hidden-files is set. publish/wwwroot contains .nojekyll,
+      # which the "Disable Jekyll" step above calls load-bearing.
+      #
+      # Strictly it is not, today: with the Pages source set to GitHub Actions the tar is
+      # served as-is and Jekyll never runs at all. But that is a fact about a setting in
+      # the repository's own web UI, changeable by anyone with admin rights and invisible
+      # from here, and if it changes then Jekyll ignores directories beginning with an
+      # underscore — the whole of _framework/ — and the application 404s with a green
+      # build. This input makes the disagreement moot rather than resolving it in favour
+      # of the weaker reading.
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: publish/wwwroot
+          include-hidden-files: true
+
+      # The exclusion above happens INSIDE the action, while it builds the tar. The
+      # artifact completeness check earlier in this job reads publish/wwwroot, so it
+      # inspects the directory and would go on passing if the tar dropped the file. The
+      # tar is the only place this claim is observable.
+      - name: Assert the dotfiles survived the tar
+        run: |
+          set -euo pipefail
+          tar="${RUNNER_TEMP}/artifact.tar"
+          test -f "$tar" || { echo "::error::no artifact tar at $tar"; exit 1; }
+
+          # Listed to a file rather than piped into grep, and that is not style.
+          # `grep -q` exits on its first match, tar then takes SIGPIPE and returns 141,
+          # and under `pipefail` the pipeline reports failure — so a PRESENT file reads
+          # as missing whenever it happens to be listed early. Measured: on a 20,000
+          # entry tar an early match gives `pipeline status=141` every time, while a
+          # match on the last entry passes, because there grep reads to the end anyway.
+          # .nojekyll is currently last in this artifact, so the piped form would have
+          # worked by accident until the ordering changed and then blocked a deploy on
+          # a perfectly good build.
+          entries="${RUNNER_TEMP}/artifact-entries.txt"
+          tar -tf "$tar" > "$entries"
+
+          if grep -qE '(^|/)\.nojekyll$' "$entries"; then
+            echo ".nojekyll is in the artifact tar ($(wc -l < "$entries") entries)"
+          else
+            echo "::error::.nojekyll is missing from the artifact tar; upload-pages-artifact excludes dotfiles unless include-hidden-files is true"
+            head -20 "$entries"
+            exit 1
+          fi
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
Closes #46

## What

`actions/upload-pages-artifact` from `v3` to `v5`, with `include-hidden-files: true`, plus
a step asserting `.nojekyll` is present **in the produced tar**.

## Why the bump

The Pages build has ended with this on every run since #42:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but are
being forced to run on Node.js 24: actions/upload-artifact@v4.
```

That `v4` is not one of ours — #42 moved every action this repository declares. It is
bundled inside `upload-pages-artifact@v3`, the last version pinned to it. `v5` bundles
`upload-artifact@v7`, which is what our own upload steps already use.

## Why the bump alone would have been wrong

`v4` changed the tar to be built with `--exclude=.[^/]*`, so **dotfiles are dropped by
default**; `v5` added `include-hidden-files` to restore them. This artifact contains
`.nojekyll`.

Whether losing it would break the deploy today is arguable, and the honest answer is
probably not: with the Pages source set to GitHub Actions the tar is served as-is and
Jekyll never runs. But that is a fact about a setting in the repository's web UI, not
about this workflow — changeable by any admin and invisible from here — and if it changes,
Jekyll ignores directories beginning with an underscore, which is the entire Blazor
runtime in `_framework/`. The application would 404 with a green build. The workflow's own
"Disable Jekyll" step already calls the file load-bearing; the input makes the
disagreement moot rather than quietly resolving it in favour of the weaker reading.

## Why a new check, and where it reads from

The exclusion happens **inside the action**, while it builds the tar. The existing
completeness check reads `publish/wwwroot`, so it inspects the directory — which still
contains the file the tar dropped — and would go on passing. The tar at
`${RUNNER_TEMP}/artifact.tar` is the only place the claim is observable.

## Proved, not assumed

#43 records four probes in this repository that proved nothing, so the check was run
against a fixture tarred both ways before being committed:

| fixture | result |
|---|---|
| tar built as `v3` does (dotfiles kept) | passes |
| tar built as `v4`/`v5` default (`--exclude=.[^/]*`) | **exits 1** and names the missing input |

That fixture then caught a second defect, in the check itself. Written the obvious way as
`tar -tf "$tar" | grep -q ...` under `set -o pipefail`, `grep -q` exits at its first match,
`tar` takes SIGPIPE and returns 141, and the pipeline reports failure — so a file that **is**
present reads as missing whenever it happens to be listed early:

```
$ tar -tf big.tar | grep -qF ./_framework/f12851.wasm   # entry 3 of 20,003
pipeline status=141
```

Every run on the 20,000-entry fixture reported `MISSING` for an entry that was there. A
match on the *final* entry passes, because there `grep` reads to the end anyway — and
`.nojekyll` is currently last in this artifact, so the piped form would have worked by
accident and then blocked a deploy on a perfectly good build the day the ordering changed.
The listing now goes to a file and there is no pipeline; re-verified across all four cases,
including the one that previously false-failed.

## Risk

Touches `.github/workflows/**`, a protected path (`ROADMAP.md` §5). The deploy job itself
is unchanged, and the build job runs on pull requests, so the new step and the bumped
action are both exercised here before they can affect a publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_