### PR TITLE
Cover the mid-edit removal, and record why its values cannot be the assertion

### DIFF
--- a/tests/e2e/smoke.mjs
+++ b/tests/e2e/smoke.mjs
@@ -173,7 +173,66 @@ await check('5  removing a member does not rebind other rows', async () => {
     assert(drift.length === 0,
         `${drift.length} surviving row(s) now show a different member than the DOM node ` +
         `they belong to: ${JSON.stringify(drift)}`);
-    return `${before.length} rows -> ${before.length - 1}, every surviving node kept its member`;
+
+    // ── the mid-edit removal from #13's own description ──
+    //
+    // The VALUES are not the observable here, and that is worth writing down because
+    // #43's acceptance criterion assumed they were ("assert no member's name has
+    // changed"). Blur fires before click, so a pending edit commits to the correct
+    // member before the removal is processed, and a positional re-render then writes a
+    // correct model back over the rows: measured against a fixture, keyed and unkeyed
+    // end with byte-identical text, so an assertion on the names passes in both and is
+    // therefore not a check at all.
+    //
+    // What differs is the DOM NODE. With @key the node travels with its member and
+    // survives a removal elsewhere; without it the renderer keeps the nodes where they
+    // are and destroys the LAST one — which is the node being typed into. That is where
+    // caret position, native validation state and an open <select> live, and it is what
+    // the @key comment in Index.razor says the fix is for. Measured on the same fixture:
+    // node survives with @key, destroyed without.
+    const TYPED = 'Edited mid-flight';
+    const remaining = await page.locator('.team-table tbody tr').count();
+    const edited = page.locator('.team-table tbody tr').nth(remaining - 1).locator('input[type=text]');
+
+    // pressSequentially, never fill(): fill dispatches `change` itself, so the value is
+    // already committed and there is no pending edit left to lose.
+    await edited.click();
+    await edited.press('ControlOrMeta+a');
+    await edited.pressSequentially(TYPED, { delay: 5 });
+    assert(await edited.inputValue() === TYPED, 'the typed value never reached the field');
+
+    // Hold the exact node, then remove a DIFFERENT row. Deliberately no blur: the click
+    // is what blurs it, which is the whole of the scenario.
+    // activeElement rather than the locator's node, because what is at stake is the
+    // element holding the CARET. Guarded, though: if focus were ever on <body> the
+    // isConnected assertion below would be trivially true and could not fail.
+    const stashed = await page.evaluate(() => {
+        window.__editedNode = document.activeElement;
+        const el = window.__editedNode;
+        return el ? `${el.tagName}:${el.getAttribute('type') || ''}` : 'null';
+    });
+    assert(stashed === 'INPUT:text',
+        `expected the caret to be in the edited name field, but focus was on ${stashed} — ` +
+        `the survival assertion below would be vacuous`);
+
+    await page.locator('.team-table tbody tr').nth(0).locator('.btn-remove').click();
+    await page.waitForFunction(
+        (n) => document.querySelectorAll('.team-table tbody tr').length === n - 1,
+        remaining, { timeout: 15_000 });
+
+    const survived = await page.evaluate(() => ({
+        connected: window.__editedNode.isConnected,
+        value: window.__editedNode.value,
+    }));
+    assert(survived.connected,
+        `the row being edited was destroyed by removing a different row — without @key ` +
+        `the renderer keeps the nodes in place and drops the last one, taking the caret ` +
+        `and any uncommitted native state with it (the node still held "${survived.value}")`);
+    assert(survived.value === TYPED,
+        `the edited node survived but now shows "${survived.value}" rather than "${TYPED}"`);
+
+    return `${before.length} rows -> ${before.length - 1}, every surviving node kept its ` +
+        `member; a row edited mid-flight survived a removal elsewhere`;
 });
 
 // ── 6. Configuration survives a reload (#14) ─────────────────────────


### PR DESCRIPTION
Closes #48

## The criterion, and why the obvious form of it is not a check

#43 asked check 5 to *"type into the last row's name field without blurring, remove a middle
row, and assert no member's name has changed."* What shipped stamped the existing values and
asserted node/member correspondence instead — which does catch the #13 defect, but is not the
scenario described.

Writing the specified assertion shows why it was the wrong one. **Blur fires before click**,
so a pending edit commits to the correct member *before* the removal is processed, and a
positional re-render then writes a correct model back over the rows. Measured on a fixture
modelling both behaviours, keyed and unkeyed end with byte-identical text:

```
[keyed]   PASS  pending edit committed to its own member across the removal
[unkeyed] PASS  pending edit committed to its own member across the removal
```

An assertion on the resulting names passes either way. It cannot fail, and #43's own rule is
that a check whose failure mode has not been exercised is not evidence — this would have been
the fifth probe in this repository that proved nothing.

## What actually differs

The **DOM node**. With `@key` the node travels with its member and survives a removal
elsewhere; without it the renderer keeps the nodes where they are and destroys the *last*
one — the node being typed into, which is where the caret, native validation state and an
open `<select>` live. That is precisely what the `@key` comment in `Index.razor` says the fix
is for, and nothing had ever executed it:

```
[keyed]   editedNodeStillInDocument=true   itsValue="Edited mid-flight"
[unkeyed] editedNodeStillInDocument=false  itsValue="Edited mid-flight"
```

Note the values agree in both rows. That is the finding.

## Proving the new assertion has teeth

Under the plain unkeyed fixture the **earlier** stamp assertion fires first, so the new one is
never reached and its teeth stay unproven — which is its own version of the same trap. A third
fixture mode, `renode`, keeps the values correct and recreates only the last row's node, so the
new assertion is what goes red:

| fixture | outcome |
|---|---|
| `keyed` | `PASS  7 rows -> 6, every surviving node kept its member; a row edited mid-flight survived a removal elsewhere` |
| `renode` (node identity lost, values correct) | `FAIL  the row being edited was destroyed by removing a different row …` |
| `unkeyed` (both lost) | `FAIL  4 surviving row(s) now show a different member than the DOM node they belong to …` |

The fixture runs check 5's body **extracted from `smoke.mjs` at run time** rather than a
retyped copy, so the thing proved and the thing shipped cannot drift apart.

## Two details that would otherwise make it vacuous

- `pressSequentially`, never `fill()`. `fill` dispatches `change` itself, so there is no
  pending edit left to lose and the scenario evaporates.
- The stashed node is read from `document.activeElement`, because the caret is what is at
  stake — but if focus were ever on `<body>` then `isConnected` would be trivially true and
  the assertion could not fail. Focus is asserted to be on the text input first.

## Risk

`tests/e2e/**` only; no workflow change, so no protected path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_