### PR TITLE
Add a local runner for the browser smoke test, and say when 4/7 is healthy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,7 @@ untested command is the same defect as a committed-but-never-executed config.
 | **CI / Format check** | `dotnet format SupercompensationApp.sln --verify-no-changes --severity error` |
 | **Secret scan / gitleaks** | `docker run --rm -v "$PWD:/repo" -w /repo zricethezav/gitleaks:v8.28.0 git /repo --config=/repo/.gitleaks.toml --redact --no-banner --verbose` |
 | **Deploy GitHub Pages / Build** | `dotnet publish SupercompensationApp.csproj -c Release -o publish` |
+| **Deploy GitHub Pages / browser smoke test** | `tests/e2e/run-local.sh` — publishes, rewrites the base href, serves the artifact and drives it in Chromium. Read the note below before acting on a failure. |
 | **CodeQL** | Not reproducible locally without the CodeQL CLI; it runs on every pull request. |
 
 ### If the format check fails
@@ -112,6 +113,36 @@ CI red the other way.
 So when the check fails locally, first run it on a clean tree. If the same files complain
 there, it is your SDK and not your change, and the fix is to leave them alone — CI is the
 authority, because CI is what gates the merge.
+
+### The browser smoke test, and the three checks that need the network
+
+`tests/e2e/run-local.sh` runs the same seven checks CI does, against a real publish served
+under the real base path. It mirrors the `build` job in `pages.yml` and is deliberately not a
+second source of truth: if the two disagree, the workflow is right, because the workflow gates
+the merge.
+
+It is worth running before pushing anything that touches a component, a route, the CDN script
+tags or `wwwroot/`. It is the check that has found the most defects here — an unreadable chart
+title, phase bands misplaced by a factor of five, a Generate button that navigated out of the
+application on the deployed site, a restored configuration that never reached the input, and
+SRI hashes that had never once been served to a browser — and none of the others could see
+any of them.
+
+**Checks 2, 3 and 4 need `cdn.jsdelivr.net`.** They are what exercises Chart.js and the
+integrity hashes, so they cannot be made offline without giving up the only thing that proves
+those hashes are right. Behind a proxy that cannot reach it you get:
+
+```
+FAIL  2  the chart renders
+         window.Chart is undefined — the CDN script did not execute.
+...
+4/7 checks passed
+Failed: 2, 3, 4
+```
+
+with `net::ERR_TUNNEL_CONNECTION_FAILED` in the console list. **That is the network, not the
+application.** Checks 1, 5, 6 and 7 need nothing external, so `4/7` with exactly that failure
+set is the healthy offline result; anything else is worth reading properly.
 
 **Two things `dotnet format` does not cover**, so a green format check is not a claim
 about them: it operates on Roslyn compilation units, so the `.razor` files and

--- a/tests/e2e/run-local.sh
+++ b/tests/e2e/run-local.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Runs the browser smoke test against a locally published artifact.
+#
+# This mirrors the `build` job in .github/workflows/pages.yml. It is a convenience, NOT a
+# second source of truth: if the two ever disagree, the workflow is right, because the
+# workflow is what gates the merge. Keep the ORDER in particular — the <base href> rewrite
+# has to happen before 404.html is copied, or the fallback carries the wrong base and the
+# deep-link check fails for a reason that has nothing to do with the deep links.
+#
+# Usage:  tests/e2e/run-local.sh [port]
+#
+# NETWORK: checks 2, 3 and 4 load Chart.js from cdn.jsdelivr.net, because they are what
+# exercises the SRI hashes. Behind a proxy that cannot reach it they fail with
+# ERR_TUNNEL_CONNECTION_FAILED and `window.Chart is undefined`, and you get 4/7. That is the
+# network, not the application. Checks 1, 5, 6 and 7 need nothing external.
+set -euo pipefail
+
+port="${1:-8080}"
+base="/SupercompensationApp/"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+out="$(mktemp -d)"
+cd "$root"
+
+cleanup() {
+  [[ -n "${server:-}" ]] && kill "$server" 2>/dev/null || true
+  rm -rf "$out"
+}
+trap cleanup EXIT
+
+echo "==> publishing"
+dotnet publish SupercompensationApp.csproj -c Release -o "$out/publish" >/dev/null
+
+index="$out/publish/wwwroot/index.html"
+
+echo "==> rewriting <base href> to $base"
+# Grepped first for the same reason pages.yml greps: if the committed tag is ever
+# reformatted, the sed silently matches nothing and every asset resolves against the wrong
+# root, which shows up as a blank page and no failed step.
+grep -q '<base href="/" />' "$index" \
+  || { echo "could not find the expected <base href=\"/\" /> in $index" >&2; exit 1; }
+sed -i "s|<base href=\"/\" />|<base href=\"$base\" />|" "$index"
+
+echo "==> adding the SPA fallback and .nojekyll"
+cp "$index" "$out/publish/wwwroot/404.html"
+touch "$out/publish/wwwroot/.nojekyll"
+
+echo "==> serving on $port"
+node tests/e2e/serve.mjs "$out/publish/wwwroot" "$base" "$port" >"$out/serve.log" 2>&1 &
+server=$!
+
+for _ in $(seq 1 30); do
+  curl -fsS -o /dev/null "http://localhost:$port$base" && break
+  sleep 1
+done
+curl -fsS -o /dev/null "http://localhost:$port$base" \
+  || { echo "the static server never came up:" >&2; cat "$out/serve.log" >&2; exit 1; }
+
+if [[ ! -d tests/e2e/node_modules ]]; then
+  echo "==> installing Playwright"
+  (cd tests/e2e && npm install --no-audit --no-fund >/dev/null)
+  (cd tests/e2e && npx playwright install --with-deps chromium >/dev/null)
+fi
+
+echo "==> driving it"
+node tests/e2e/smoke.mjs "http://localhost:$port$base"


### PR DESCRIPTION
Closes #52

## The gap

`CONTRIBUTING.md` opens its **Reproducing CI locally** table with a completeness claim:

> **Every command below is the one CI runs**, minus flags that exist only to produce CI
> artifacts.

The browser smoke test was not in it. So the check that has found the most defects here —
an unreadable chart title, phase bands out by a factor of five, a Generate button that
navigated out of the application on the deployed site, a restored configuration that never
reached the input, and SRI hashes that had never once been served to a browser — was the one
a contributor could not run before pushing. Its feedback loop was a full CI round, and #45
spent three of those on a single defect.

## `tests/e2e/run-local.sh`

Publishes, rewrites the base href, adds the fallback, serves under the real base path, drives
it. It mirrors the `build` job in `pages.yml` and its header says it is **not** a second
source of truth: if the two disagree the workflow is right, because the workflow gates the
merge.

One ordering constraint is commented because it is not obvious and fails confusingly: the
`<base href>` rewrite must happen **before** `404.html` is copied, or the fallback carries the
wrong base and the deep-link check fails for a reason that has nothing to do with deep links.
The `grep` before the `sed` is kept for the same reason `pages.yml` keeps it — if the
committed tag is ever reformatted the `sed` silently matches nothing, every asset resolves
against the wrong root, and the symptom is a blank page with no failed step.

## The caveat, which matters more than the commands

**Checks 2, 3 and 4 need `cdn.jsdelivr.net`.** They are what exercises Chart.js and the
integrity hashes from #4, so they cannot be made offline without giving up the only thing that
proves those hashes are right. Behind a restrictive proxy:

```
FAIL  2  the chart renders
         window.Chart is undefined — the CDN script did not execute.
...
4/7 checks passed
Failed: 2, 3, 4
```

with `net::ERR_TUNNEL_CONNECTION_FAILED` in the console list. That is the network, not the
application. Without this written down the next person sees three red checks and starts
"fixing" a chart that is fine — so CONTRIBUTING now states the expected failure set and that
**anything other than exactly `2, 3, 4` is worth reading properly.**

## Run, not just written

```
==> publishing
==> rewriting <base href> to /SupercompensationApp/
==> adding the SPA fallback and .nojekyll
==> serving on 8090
==> driving it
PASS  1  the application boots
PASS  5  removing a member does not rebind other rows
         7 rows -> 6, every surviving node kept its member; a row edited mid-flight survived a removal elsewhere
PASS  6  configuration survives a reload
PASS  7  deep links resolve through 404.html
4/7 checks passed   Failed: 2, 3, 4
```

## Every check has now been observed red

#43 required each assertion to be shown failing and #48 recorded that check 1 never had been.
It has now, against a faithful mutant — `index.html` served with HTTP 200 and only
`_framework/blazor.webassembly.js` removed, so the page loads and the runtime cannot start:

```
FAIL  1  the application boots
         page.waitForSelector: Timeout 90000ms exceeded.
```

The first attempt at that mutant proved nothing: the copy had not completed, the server
returned 404, and all seven failed because there was no application rather than because it
could not boot. That is the sixth probe in this repository that had to be corrected before it
meant anything, and it is why the distinction is worth stating.

| check | observed red by |
|---|---|
| 1 boots | the mutant above |
| 2 chart renders | jsDelivr unreachable |
| 3 title legible | same run |
| 4 axis linear | same run |
| 5 row identity | the `keyed`/`unkeyed`/`renode` fixtures (#49) |
| 6 persistence | twice, for real (#45) |
| 7 deep links | caught passing against a static shell, then tightened (#45) |

## Risk

`tests/e2e/**` and `CONTRIBUTING.md`. No protected path, and no change to what CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_