### PR TITLE
Cover what a coverage run showed had nothing behind it

### DIFF
--- a/tests/SupercompensationApp.Tests/ChartAndLayoutTests.cs
+++ b/tests/SupercompensationApp.Tests/ChartAndLayoutTests.cs
@@ -1,0 +1,141 @@
+namespace SupercompensationApp.Tests;
+
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using SupercompensationApp.Layout;
+using SupercompensationApp.Models;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// The behaviour a coverage run showed had nothing behind it.
+///
+/// Two of these guard single points of failure. MainLayout.OnInitializedAsync is the ONLY
+/// call to AppStateService.LoadAsync in the application, so deleting that one line loses
+/// persistence entirely and nothing fails but a ninety-second browser round. And
+/// Chart.RenderChart hands the whole payload to renderSupercompChart, which is what the
+/// chart is actually drawn from — the boundary arithmetic in it is the same quantity that
+/// was wrong in #9.
+///
+/// Every test here was confirmed red by breaking the thing it guards.
+/// </summary>
+public class ChartAndLayoutTests : BunitContext
+{
+    private readonly InMemoryStateStore _store = new();
+
+    private AppStateService NewState()
+    {
+        var state = new AppStateService(new SupercompensationService(), _store);
+        Services.AddSingleton(state);
+        return state;
+    }
+
+    // ── MainLayout is the only thing that restores ──────────────────────────────
+
+    [Fact]
+    public void RenderingTheLayoutRestoresTheStoredConfiguration()
+    {
+        var state = NewState();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var stored = new SprintConfiguration { SprintDuration = 21, NumberOfSprints = 5 };
+        _store.Seed(StateSerializer.StorageKey,
+            StateSerializer.Serialize(stored, TeamMember.GetDefaultTeam()));
+
+        Render<MainLayout>();
+
+        Assert.Equal(21, state.Config.SprintDuration);
+        Assert.Equal(5, state.Config.NumberOfSprints);
+    }
+
+    // ── What the chart is actually drawn from ───────────────────────────────────
+
+    /// <summary>
+    /// The arguments of the last renderSupercompChart call, in the order Chart.razor
+    /// passes them: days, performance, baselines, phases, sprint boundaries, show phases,
+    /// show baseline, sprint duration.
+    /// </summary>
+    private IReadOnlyList<object?> LastChartCall() =>
+        JSInterop.Invocations["renderSupercompChart"][^1].Arguments;
+
+    private AppStateService GeneratedState()
+    {
+        var state = NewState();
+        JSInterop.SetupVoid("renderSupercompChart", _ => true);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Assert.True(state.Generate(), "the default configuration must be generatable");
+        return state;
+    }
+
+    [Fact]
+    public void TheChartIsDrawnFromTheGeneratedSeries()
+    {
+        var state = GeneratedState();
+
+        Render<SupercompensationApp.Pages.Chart>();
+
+        var args = LastChartCall();
+        var days = Assert.IsType<double[]>(args[0]);
+        var performance = Assert.IsType<double[]>(args[1]);
+
+        Assert.Equal(state.LastChartData!.Days.Count, days.Length);
+        Assert.Equal(state.LastChartData.Performance.Count, performance.Length);
+        Assert.Equal(state.Config.SprintDuration, Assert.IsType<int>(args[7]));
+    }
+
+    [Fact]
+    public void TheSprintBoundariesAreTheJoinsAndNeitherEnd()
+    {
+        var state = GeneratedState();   // defaults: 3 sprints of 10 days
+
+        Render<SupercompensationApp.Pages.Chart>();
+
+        var boundaries = Assert.IsType<double[]>(LastChartCall()[4]);
+
+        // Two joins for three sprints. Day 0 is not a join and day 30 is the end of the
+        // last sprint, so an off-by-one at either end of that loop puts a phase band
+        // where no sprint changes — which is the shape of the #9 defect.
+        Assert.Equal(new double[] { 10, 20 }, boundaries);
+    }
+
+    /// <summary>
+    /// Both toggles carry the same class and are told apart by order, so the count is
+    /// asserted: adding a third would otherwise silently retarget these tests at the
+    /// wrong button and they would go on passing.
+    /// </summary>
+    private static AngleSharp.Dom.IElement Toggle(
+        Bunit.IRenderedComponent<SupercompensationApp.Pages.Chart> cut, int index)
+    {
+        var toggles = cut.FindAll(".btn-toggle");
+        Assert.Equal(2, toggles.Count);
+        return toggles[index];
+    }
+
+    [Fact]
+    public void TogglingThePhaseBandsChangesWhatTheChartIsToldToDraw()
+    {
+        GeneratedState();
+        var cut = Render<SupercompensationApp.Pages.Chart>();
+
+        Assert.True(Assert.IsType<bool>(LastChartCall()[5]), "phases start shown");
+
+        Toggle(cut, 0).Click();
+
+        Assert.False(Assert.IsType<bool>(LastChartCall()[5]));
+    }
+
+    [Fact]
+    public void TogglingTheBaselineChangesWhatTheChartIsToldToDraw()
+    {
+        GeneratedState();
+        var cut = Render<SupercompensationApp.Pages.Chart>();
+
+        Assert.True(Assert.IsType<bool>(LastChartCall()[6]), "the baseline starts shown");
+
+        Toggle(cut, 1).Click();
+
+        Assert.False(Assert.IsType<bool>(LastChartCall()[6]));
+    }
+}

--- a/tests/SupercompensationApp.Tests/DataPageAndStoreTests.cs
+++ b/tests/SupercompensationApp.Tests/DataPageAndStoreTests.cs
@@ -1,0 +1,156 @@
+namespace SupercompensationApp.Tests;
+
+using Bunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using SupercompensationApp.Services;
+using Xunit;
+
+/// <summary>
+/// The Data page's filters, and the real localStorage adapter.
+///
+/// StatePersistenceTests exercises InMemoryStateStore, which is a different class written
+/// for those tests. LocalStorageStateStore — the one the application actually runs — had
+/// no tests at all, and its behaviour is entirely about what it does when the interop
+/// FAILS. That is deliberate and documented: reading window.localStorage throws outright
+/// in a private window or when a browser is set to block site data, so the adapter turns
+/// a JSException into a null and lets the application carry on without persistence.
+///
+/// It is also what made #45 hard to diagnose, because it makes a failed read and a first
+/// visit indistinguishable to LoadAsync. Deliberate, documented and untested is one
+/// refactor away from being none of the three.
+/// </summary>
+public class DataPageAndStoreTests : BunitContext
+{
+    private AppStateService NewGeneratedState()
+    {
+        var state = new AppStateService(new SupercompensationService(), new InMemoryStateStore());
+        Services.AddSingleton(state);
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Assert.True(state.Generate());
+        return state;
+    }
+
+    private static int BodyRows(IRenderedComponent<SupercompensationApp.Pages.Data> cut) =>
+        cut.FindAll("tbody tr").Count;
+
+    /// <summary>
+    /// The two filters carry no class of their own and are told apart by order, so the
+    /// count is asserted: a third filter would otherwise silently retarget these tests.
+    /// </summary>
+    private static AngleSharp.Dom.IElement Filter(
+        IRenderedComponent<SupercompensationApp.Pages.Data> cut, int index)
+    {
+        var filters = cut.FindAll(".filter-row select");
+        Assert.Equal(2, filters.Count);
+        return filters[index];
+    }
+
+    [Fact]
+    public void TheTableShowsEveryRowUntilSomethingIsFiltered()
+    {
+        var state = NewGeneratedState();
+        var rows = state.LastTableData!;
+        var cut = Render<SupercompensationApp.Pages.Data>();
+
+        Assert.Equal(rows.Count, BodyRows(cut));
+    }
+
+    [Fact]
+    public void FilteringBySprintKeepsOnlyThatSprint()
+    {
+        var state = NewGeneratedState();
+        var rows = state.LastTableData!;
+        var cut = Render<SupercompensationApp.Pages.Data>();
+
+        Filter(cut, 0).Change("2");
+
+        var expected = rows.Count(d => d.SprintNumber == 2);
+        Assert.Equal(expected, BodyRows(cut));
+        Assert.True(expected > 0 && expected < rows.Count,
+            "the fixture has to have some rows in sprint 2 and some outside it, or this " +
+            "assertion holds for a filter that does nothing");
+    }
+
+    [Fact]
+    public void FilteringByPhaseKeepsOnlyThatPhase()
+    {
+        var state = NewGeneratedState();
+        var rows = state.LastTableData!;
+        var phase = rows.Select(d => d.Phase).First(p => !string.IsNullOrEmpty(p));
+        var cut = Render<SupercompensationApp.Pages.Data>();
+
+        Filter(cut, 1).Change(phase);
+
+        var expected = rows.Count(d => d.Phase == phase);
+        Assert.Equal(expected, BodyRows(cut));
+        Assert.True(expected < rows.Count, "the phase filter must exclude something");
+    }
+
+    [Fact]
+    public void TheTwoFiltersCompose()
+    {
+        var state = NewGeneratedState();
+        var rows = state.LastTableData!;
+        var phase = rows.Select(d => d.Phase).First(p => !string.IsNullOrEmpty(p));
+        var cut = Render<SupercompensationApp.Pages.Data>();
+
+        Filter(cut, 0).Change("2");
+        Filter(cut, 1).Change(phase);
+
+        var expected = rows.Count(d => d.SprintNumber == 2 && d.Phase == phase);
+        Assert.Equal(expected, BodyRows(cut));
+
+        // Composition is the point: it must be narrower than either filter alone, or the
+        // second one is being dropped and this test would pass on a single filter.
+        Assert.True(expected < rows.Count(d => d.SprintNumber == 2));
+        Assert.True(expected < rows.Count(d => d.Phase == phase));
+    }
+
+    // ── The real adapter, which only has behaviour when the interop fails ────────
+
+    /// <summary>An IJSRuntime that throws, which is what a private window produces.</summary>
+    private sealed class ThrowingJsRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            throw new JSException("localStorage is not available");
+
+        public ValueTask<TValue> InvokeAsync<TValue>(
+            string identifier, CancellationToken cancellationToken, object?[]? args) =>
+            throw new JSException("localStorage is not available");
+    }
+
+    [Fact]
+    public async Task AReadThatThrowsIsReportedAsNothingStoredRatherThanCrashing()
+    {
+        var store = new LocalStorageStateStore(new ThrowingJsRuntime());
+
+        Assert.Null(await store.ReadAsync(StateSerializer.StorageKey));
+    }
+
+    [Fact]
+    public async Task AWriteThatThrowsIsSwallowed()
+    {
+        var store = new LocalStorageStateStore(new ThrowingJsRuntime());
+
+        // Losing the write is strictly better than losing the session, so this must not
+        // propagate — the application works without persistence.
+        await store.WriteAsync(StateSerializer.StorageKey, "{}");
+        await store.RemoveAsync(StateSerializer.StorageKey);
+    }
+
+    [Fact]
+    public async Task AFailedRestoreIsNotReportedToTheUserAsCorruption()
+    {
+        var state = new AppStateService(
+            new SupercompensationService(), new LocalStorageStateStore(new ThrowingJsRuntime()));
+
+        await state.LoadAsync();
+
+        // RestoreFailed means "a payload was found and could not be used". Storage being
+        // unavailable is not that, and telling a private-window user their configuration
+        // was corrupt would be wrong.
+        Assert.False(state.RestoreFailed);
+        Assert.Equal(10, state.Config.SprintDuration);
+    }
+}


### PR DESCRIPTION
Closes #54

## How this was chosen

`coverlet.collector` has been a package reference since #6 and had **never been run**. Doing
so gives **78.4% line, 65.9% branch** — unevenly spread. `SupercompensationService` (176
lines), `AppStateService`, `CsvExporter` and the models are at 100%; `Index` reached 100% in
#51. Two single points of failure had nothing at all.

## The two that matter most

**`MainLayout.OnInitializedAsync` was at 0%, and it is the only call to
`AppStateService.LoadAsync` in the application.** Delete that line and persistence is gone
entirely, with nothing failing but a ninety-second browser round. It is the other half of the
#45 defect and it was completely unguarded.

**`Chart.RenderChart` was at 0%, and it is what the chart is drawn from.** Its sprint-boundary
loop computes the same quantity that was wrong in #9. bUnit records interop arguments, so the
payload is assertable without a browser:

```csharp
// Two joins for three sprints. Day 0 is not a join and day 30 is the end of the last
// sprint, so an off-by-one at either end of that loop puts a phase band where no sprint
// changes — which is the shape of the #9 defect.
Assert.Equal(new double[] { 10, 20 }, boundaries);
```

## And the adapter that had no tests at all

`StatePersistenceTests` exercises `InMemoryStateStore` — a different class, written for those
tests. `LocalStorageStateStore`, the one the application runs, was at 0%, and its behaviour is
entirely about what it does when the interop **fails**. That is deliberate and documented (a
private window throws on `window.localStorage` before a key is even named), and it is also
what made #45 ambiguous, because it renders a failed read indistinguishable from a first
visit. Deliberate, documented and untested is one refactor away from being none of the three.

## Result

| | before | after |
|---|---|---|
| line | 78.4% | **94.9%** |
| branch | 65.9% | **88.6%** |
| `MainLayout` | 0.0% | 100.0% |
| `LocalStorageStateStore` | 0.0% | 88.2% |
| `Data` | 22.6% | 96.8% |
| `Chart` | 25.5% | 84.3% |

`Program.cs` stays uncovered and is deliberately out of scope — it builds a
`WebAssemblyHost`.

## Ten mutants, each failing exactly its own tests

| Mutation | Went red |
|---|---|
| `MainLayout` stops calling `LoadAsync` | the restore test |
| boundary loop starts at `0` | the boundary test |
| boundary loop runs one too far | the boundary test |
| phases pinned on | the phase-toggle test |
| baseline pinned on | the baseline-toggle test |
| `Data` drops the sprint filter | that filter test **and** the composition test |
| `Data` drops the phase filter | that filter test **and** the composition test |
| `ReadAsync` stops catching `JSException` | the read test and the restore test |
| `WriteAsync` stops catching | the write test |
| an empty store reported as corruption | 3 tests, including two pre-existing ones |

Both filter mutants failing the composition test is the point of that test: it proves the two
filters actually compose rather than one masking the other.

The first attempt at the toggle mutant **proved nothing again** — `ShowPhases = ShowPhases` is
`CS1717`, so with warnings-as-errors it broke the *build* rather than the *test*. That is the
third time in this repository, so the mutant is now `ShowPhases = true`: a change that compiles
and defeats the button.

## Two selector helpers, and why they assert a count

Both chart toggles carry the same class, and the two `Data` filters carry none, so each is
found by order. Each helper asserts there are exactly two — otherwise adding a third would
silently retarget these tests at the wrong control and they would go on passing.

## Verified locally

```
build     0 Warning(s)  0 Error(s)
test      Passed! - Failed: 0, Passed: 68, Skipped: 0, Total: 68
format    18 errors, all pre-existing and all in CsvExporter.cs / CsvExporterTests.cs
          (the SDK-band divergence documented in #51) — 0 in the new files
```

## Risk

`tests/**` only. No protected path, no change to the application or to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTNaJH5cAAVtzczdfgi9qo)_